### PR TITLE
fix: rename LANG_* enum to avoid Windows macro clash

### DIFF
--- a/include/localization.h
+++ b/include/localization.h
@@ -17,11 +17,11 @@ extern "C" {
  * Language enumeration
  * =================================================================== */
 typedef enum {
-    LANG_ENGLISH = 0,
-    LANG_SPANISH = 1,
-    LANG_FRENCH = 2,
-    LANG_GERMAN = 3,
-    LANG_COUNT = 4
+    LOC_LANG_ENGLISH = 0,
+    LOC_LANG_SPANISH = 1,
+    LOC_LANG_FRENCH = 2,
+    LOC_LANG_GERMAN = 3,
+    LOC_LANG_COUNT = 4
 } Language;
 
 /* ===================================================================

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -1063,7 +1063,7 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
                 16, 140, 220, 200, w, (HMENU)(INT_PTR)IDC_CMB_LANG,
                 g_app.inst, NULL);
             int cur_lang = (int)localization_get_language();
-            for (i = 0; i < LANG_COUNT; ++i) {
+            for (i = 0; i < LOC_LANG_COUNT; ++i) {
                 SendMessageA(cmb, CB_ADDSTRING, 0,
                     (LPARAM)localization_get_language_name((Language)i));
             }
@@ -1225,7 +1225,7 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
         case IDC_BTN_LANG_APPLY: {  /* @req SWR-GUI-012 */
             HWND cmb = GetDlgItem(w, IDC_CMB_LANG);
             int sel_lang = (int)SendMessageA(cmb, CB_GETCURSEL, 0, 0);
-            if (sel_lang >= 0 && sel_lang < LANG_COUNT) {
+            if (sel_lang >= 0 && sel_lang < LOC_LANG_COUNT) {
                 localization_set_language((Language)sel_lang);
                 app_config_save_language(sel_lang);
                 /* Close and reopen Settings to refresh all localized labels */

--- a/src/localization.c
+++ b/src/localization.c
@@ -12,7 +12,7 @@
 /* ===================================================================
  * Global language state (static, no heap)
  * =================================================================== */
-static Language g_current_language = LANG_ENGLISH;
+static Language g_current_language = LOC_LANG_ENGLISH;
 
 /* ===================================================================
  * String tables (4 languages x 100+ strings)
@@ -307,7 +307,7 @@ static const char* g_strings_german[STR_COUNT] = {
 };
 
 /* All language tables */
-static const char** g_string_tables[LANG_COUNT] = {
+static const char** g_string_tables[LOC_LANG_COUNT] = {
     g_strings_english,
     g_strings_spanish,
     g_strings_french,
@@ -317,7 +317,7 @@ static const char** g_string_tables[LANG_COUNT] = {
 /* ===================================================================
  * Language names (for display in UI)
  * =================================================================== */
-static const char* g_language_names[LANG_COUNT] = {
+static const char* g_language_names[LOC_LANG_COUNT] = {
     "English",
     "Español",
     "Français",
@@ -330,7 +330,7 @@ static const char* g_language_names[LANG_COUNT] = {
 
 void localization_set_language(Language lang)
 {
-    if (lang >= 0 && lang < LANG_COUNT) {
+    if (lang >= 0 && lang < LOC_LANG_COUNT) {
         g_current_language = lang;
     }
 }
@@ -350,7 +350,7 @@ const char* localization_get_string(StringID id)
 
 const char* localization_get_language_name(Language lang)
 {
-    if (lang >= 0 && lang < LANG_COUNT) {
+    if (lang >= 0 && lang < LOC_LANG_COUNT) {
         return g_language_names[lang];
     }
     return "Unknown";


### PR DESCRIPTION
## Summary

Fixes the build failure on Windows. `<winnt.h>` defines `LANG_ENGLISH`, `LANG_SPANISH`, `LANG_FRENCH`, `LANG_GERMAN` as macros. When `gui_main.c` includes `<windows.h>` then `localization.h`, the preprocessor expands these inside the enum causing compile errors.

Renamed to `LOC_LANG_ENGLISH`, `LOC_LANG_SPANISH`, etc.

## Change Checklist

- [x] User needs reviewed and updated if needed
- [x] System requirements reviewed and updated if needed
- [x] Software requirements reviewed and updated if needed
- [x] README or other documentation reviewed and updated if needed
- [x] Unit tests reviewed and updated if needed
- [x] Integration tests reviewed and updated if needed
- [x] DVT tests reviewed and updated if needed
- [x] Coverage impact reviewed
- [x] Release artifact impact reviewed