### PR TITLE
fix: coverage via gcov, DVT report-only, publish on PR+main, local script

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,9 +6,10 @@
 #   2. Static Analysis (cppcheck) + SAST (CodeQL)   [parallel]
 #   3. Unit & Integration Tests
 #   4. Code Coverage
-#   5. DVT — Design Verification Tests
-#   6. Release Artifacts                             [tags only]
+#   5. DVT — Design Verification Report (from stage 3 results)
+#   6. Publish Reports (artifact always; GitHub Pages on main only)
 #
+# Release artifacts are built by release.yml on tag push (v*).
 # IEC 62304 Class B — full verification pipeline.
 # =====================================================================
 
@@ -301,6 +302,10 @@ jobs:
 
   # ═══════════════════════════════════════════════════════════════════
   # Stage 4 — Code Coverage
+  #
+  # Builds with --coverage, runs tests, then uses gcov directly to
+  # parse .gcda/.gcno files and a Python script to produce Cobertura
+  # XML + HTML. This avoids gcovr path-matching issues on Windows.
   # ═══════════════════════════════════════════════════════════════════
   coverage:
     name: "4 — Code Coverage"
@@ -331,43 +336,138 @@ jobs:
 
       - name: Run tests for coverage data
         run: |
-          ./build_cov/tests/test_unit.exe || true
-          ./build_cov/tests/test_integration.exe || true
+          echo "=== Running unit tests ==="
+          ./build_cov/tests/test_unit.exe --gtest_brief=1 2>&1; echo "Exit: $?"
+          echo "=== Running integration tests ==="
+          ./build_cov/tests/test_integration.exe --gtest_brief=1 2>&1; echo "Exit: $?"
 
       - name: Generate coverage report
         run: |
-          pip install gcovr
           mkdir -p coverage-report
 
-          echo "--- Searching for .gcda files ---"
-          find build_cov -name '*.gcda' 2>/dev/null | head -20 || echo "(none found via find)"
-          ls build_cov/CMakeFiles/monitor_lib.dir/src/*.gcda 2>/dev/null || echo "(no gcda in expected dir)"
+          echo "=== .gcno files ==="
+          find build_cov -name '*.gcno' | head -15
+          echo "=== .gcda files ==="
+          find build_cov -name '*.gcda' | head -15
 
-          echo "--- Running gcovr ---"
-          gcovr --root . \
-            --search-path build_cov \
-            --gcov-executable gcov \
-            --filter 'src/' \
-            --xml coverage-report/coverage.xml \
-            --html-details coverage-report/index.html \
-            --print-summary 2>&1 || echo "gcovr exited with error"
+          # Run gcov on each source file's .gcda
+          GCDA_DIR="build_cov/CMakeFiles/monitor_lib.dir/src"
+          echo "=== Running gcov on monitor_lib sources ==="
+          for gcda in "$GCDA_DIR"/*.gcda; do
+            [ -f "$gcda" ] && gcov -o "$GCDA_DIR" "$gcda" 2>/dev/null
+          done
+          ls *.gcov 2>/dev/null | head -10 || echo "(no .gcov files produced)"
 
-          # Ensure coverage artifact always exists (placeholder if gcovr failed)
-          if [ ! -f coverage-report/coverage.xml ]; then
-            echo "--- gcovr produced no output, writing placeholder ---"
-            cat > coverage-report/coverage.xml << 'XMLEOF'
-          <?xml version="1.0" ?>
-          <coverage version="6.0" line-rate="0" branch-rate="0" lines-covered="0" lines-valid="0" branches-covered="0" branches-valid="0">
-            <packages/>
-          </coverage>
-          XMLEOF
-            cat > coverage-report/index.html << 'HTMLEOF'
-          <html><body><h1>Coverage report unavailable</h1>
-          <p>gcovr did not produce output. Check the pipeline coverage step logs.</p>
-          </body></html>
-          HTMLEOF
-          fi
-          echo "--- coverage-report contents ---"
+          # Use Python to parse gcov output → Cobertura XML + HTML
+          python3 - << 'PYEOF'
+          import os, glob, re, json
+
+          src_dir = "src"
+          gcov_files = glob.glob("*.gcov")
+          print(f"Found {len(gcov_files)} .gcov files")
+
+          files_data = {}
+          total_lines = 0
+          covered_lines = 0
+          total_branches = 0
+          covered_branches = 0
+
+          for gcov_file in gcov_files:
+              # Extract original source filename from gcov file
+              # gcov files are named like "vitals.c.gcov"
+              src_name = gcov_file.replace(".gcov", "")
+              src_path = os.path.join(src_dir, src_name)
+
+              if not os.path.exists(src_path):
+                  continue
+
+              lines = []
+              with open(gcov_file, "r", errors="replace") as f:
+                  for raw_line in f:
+                      parts = raw_line.split(":", 2)
+                      if len(parts) < 3:
+                          continue
+                      count_str = parts[0].strip()
+                      line_no = parts[1].strip()
+                      if not line_no.isdigit():
+                          continue
+                      ln = int(line_no)
+                      if ln == 0:
+                          continue
+                      if count_str == "-":
+                          continue  # non-executable
+                      elif count_str.startswith("#") or count_str == "0":
+                          lines.append((ln, 0))
+                          total_lines += 1
+                      else:
+                          try:
+                              hits = int(count_str)
+                              lines.append((ln, hits))
+                              total_lines += 1
+                              if hits > 0:
+                                  covered_lines += 1
+                          except ValueError:
+                              continue
+
+              if lines:
+                  files_data[src_path] = lines
+
+          line_rate = covered_lines / total_lines if total_lines > 0 else 0
+          branch_rate = 0  # gcov basic mode doesn't give branch info
+
+          print(f"Coverage: {covered_lines}/{total_lines} lines = {line_rate*100:.1f}%")
+          print(f"Files with coverage: {len(files_data)}")
+
+          # Write Cobertura XML
+          xml_lines = [
+              '<?xml version="1.0" ?>',
+              f'<coverage version="6.0" line-rate="{line_rate:.4f}" branch-rate="{branch_rate:.4f}"',
+              f'  lines-covered="{covered_lines}" lines-valid="{total_lines}"',
+              f'  branches-covered="{covered_branches}" branches-valid="{total_branches}">',
+              '<packages><package name="src" line-rate="{:.4f}"><classes>'.format(line_rate),
+          ]
+          for src_path, lines in files_data.items():
+              fname = os.path.basename(src_path)
+              file_covered = sum(1 for _, h in lines if h > 0)
+              file_total = len(lines)
+              file_rate = file_covered / file_total if file_total > 0 else 0
+              xml_lines.append(f'<class name="{fname}" filename="{src_path}" line-rate="{file_rate:.4f}">')
+              xml_lines.append('<lines>')
+              for ln, hits in lines:
+                  xml_lines.append(f'<line number="{ln}" hits="{hits}"/>')
+              xml_lines.append('</lines></class>')
+          xml_lines.append('</classes></package></packages></coverage>')
+
+          with open("coverage-report/coverage.xml", "w") as f:
+              f.write("\n".join(xml_lines))
+
+          # Write HTML summary
+          html = ['<!DOCTYPE html><html><head><meta charset="utf-8">',
+                  '<title>Code Coverage Report</title>',
+                  '<style>body{font-family:sans-serif;max-width:900px;margin:0 auto;padding:2rem}',
+                  'table{border-collapse:collapse;width:100%}th,td{border:1px solid #ccc;padding:.5rem}',
+                  'th{background:#1e3a8a;color:#fff}.good{color:#16a34a}.bad{color:#dc2626}</style>',
+                  '</head><body>',
+                  f'<h1>Code Coverage: {line_rate*100:.1f}%</h1>',
+                  f'<p>{covered_lines} of {total_lines} lines covered</p>',
+                  '<table><tr><th>File</th><th>Lines</th><th>Covered</th><th>Rate</th></tr>']
+          for src_path, lines in sorted(files_data.items()):
+              fname = os.path.basename(src_path)
+              fc = sum(1 for _, h in lines if h > 0)
+              ft = len(lines)
+              fr = fc / ft * 100 if ft > 0 else 0
+              cls = "good" if fr >= 80 else "bad"
+              html.append(f'<tr><td>{fname}</td><td>{ft}</td><td>{fc}</td>'
+                          f'<td class="{cls}">{fr:.1f}%</td></tr>')
+          html.append('</table></body></html>')
+
+          with open("coverage-report/index.html", "w") as f:
+              f.write("\n".join(html))
+
+          print("Reports written to coverage-report/")
+          PYEOF
+
+          echo "=== coverage-report contents ==="
           ls -la coverage-report/
 
       - name: Coverage summary
@@ -401,50 +501,24 @@ jobs:
           retention-days: 90
 
   # ═══════════════════════════════════════════════════════════════════
-  # Stage 5 — DVT (Design Verification Tests)
+  # Stage 5 — DVT (Design Verification Report)
+  #
+  # Downloads test results from stage 3, generates the IEC 62304
+  # DVT report with per-suite SWR traceability. Does NOT re-build
+  # or re-run tests — DVT is a report-generation activity.
   # ═══════════════════════════════════════════════════════════════════
   dvt:
-    name: "5 — DVT"
+    name: "5 — DVT Report"
     needs: coverage
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory "*"
 
-      - uses: actions/cache@v4
+      - name: Download test results from stage 3
+        uses: actions/download-artifact@v4
         with:
-          path: build_dvt/_deps
-          key: gtest-dvt-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-dvt-
-
-      - name: Build
-        run: |
-          cmake -S . -B build_dvt -G Ninja \
-            -DCMAKE_C_COMPILER=gcc \
-            -DCMAKE_CXX_COMPILER=g++ \
-            -DBUILD_TESTS=ON \
-            -Wno-dev
-          cmake --build build_dvt
-
-      - name: Create output directories
-        run: mkdir -p dvt/results
-
-      - name: Run unit tests
-        run: |
-          set -o pipefail
-          ./build_dvt/tests/test_unit.exe \
-            --gtest_output=xml:dvt/results/unit_results.xml \
-            2>&1 | tee dvt/results/unit_raw.txt
-
-      - name: Run integration tests
-        run: |
-          set -o pipefail
-          ./build_dvt/tests/test_integration.exe \
-            --gtest_output=xml:dvt/results/integration_results.xml \
-            2>&1 | tee dvt/results/integration_raw.txt
+          name: test-results-${{ github.run_number }}
+          path: dvt/results
 
       - name: Generate DVT report
         run: |
@@ -465,8 +539,8 @@ jobs:
               except Exception:
                   return 0, 0, -1
 
-          u_total, u_pass, u_fail = parse_gtest_xml("dvt/results/unit_results.xml")
-          i_total, i_pass, i_fail = parse_gtest_xml("dvt/results/integration_results.xml")
+          u_total, u_pass, u_fail = parse_gtest_xml("dvt/results/results_unit.xml")
+          i_total, i_pass, i_fail = parse_gtest_xml("dvt/results/results_integration.xml")
           overall = "PASS" if (u_fail == 0 and i_fail == 0) else "FAIL"
 
           lines = [
@@ -517,8 +591,8 @@ jobs:
               except:
                   return 0, 0, -1
 
-          u_t, u_p, u_f = parse_xml("dvt/results/unit_results.xml")
-          i_t, i_p, i_f = parse_xml("dvt/results/integration_results.xml")
+          u_t, u_p, u_f = parse_xml("dvt/results/results_unit.xml")
+          i_t, i_p, i_f = parse_xml("dvt/results/results_integration.xml")
           status = lambda f: "PASS" if f == 0 else "FAIL"
 
           summary = "## DVT Results\n\n"
@@ -555,8 +629,8 @@ jobs:
                   return int(root.attrib.get("failures", 0)) + int(root.attrib.get("errors", 0))
               except:
                   return 1
-          uf = get_failures("dvt/results/unit_results.xml")
-          if_ = get_failures("dvt/results/integration_results.xml")
+          uf = get_failures("dvt/results/results_unit.xml")
+          if_ = get_failures("dvt/results/results_integration.xml")
           total = uf + if_
           if total > 0:
               print(f"DVT FAIL: {total} test(s) failed")
@@ -574,16 +648,12 @@ jobs:
   # View at: https://<owner>.github.io/<repo>/
   # ═══════════════════════════════════════════════════════════════════
   publish-reports:
-    name: "Publish Reports (GitHub Pages)"
+    name: "6 — Publish Reports"
     needs: dvt
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -732,11 +802,20 @@ jobs:
           print(f"Tests: {total_t} total, {total_f} failed")
           PYEOF
 
+      - name: Upload report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-report-${{ github.run_number }}
+          path: site/
+          retention-days: 90
+
       - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         id: deploy
         uses: actions/deploy-pages@v4

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run_pipeline.sh — Run the full CI/CD pipeline locally
+#
+# Replicates the GitHub Actions pipeline stages on a local machine.
+# Requires: cmake, ninja, gcc, g++, python3, gcov
+# Optional: gcovr (pip install gcovr) for HTML coverage
+#
+# Usage:
+#   ./scripts/run_pipeline.sh          # run all stages
+#   ./scripts/run_pipeline.sh --skip-analysis  # skip cppcheck/CodeQL
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SKIP_ANALYSIS=false
+if [ "${1:-}" = "--skip-analysis" ]; then
+    SKIP_ANALYSIS=true
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+stage() { echo -e "\n${BLUE}════════════════════════════════════════════════════════════${NC}"; echo -e "${BLUE}  Stage $1: $2${NC}"; echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}\n"; }
+pass()  { echo -e "${GREEN}  ✓ $1${NC}"; }
+fail()  { echo -e "${RED}  ✗ $1${NC}"; exit 1; }
+warn()  { echo -e "${YELLOW}  ! $1${NC}"; }
+
+# ── Stage 1: Build ────────────────────────────────────────────
+stage 1 "Build All"
+cmake -S . -B build -G Ninja \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -DBUILD_TESTS=ON \
+    -Wno-dev 2>&1 | tail -3
+cmake --build build 2>&1
+pass "Build succeeded"
+
+# ── Stage 2: Static Analysis ─────────────────────────────────
+if [ "$SKIP_ANALYSIS" = false ]; then
+    stage 2 "Static Analysis"
+    if command -v cppcheck &>/dev/null; then
+        cppcheck --enable=all --std=c11 \
+            --suppress=missingIncludeSystem \
+            --suppress=unusedFunction \
+            --suppress=missingInclude \
+            --include=include \
+            src/vitals.c src/alerts.c src/patient.c \
+            src/gui_auth.c src/gui_users.c 2>&1 | tail -5
+        pass "cppcheck completed"
+    else
+        warn "cppcheck not installed — skipping"
+    fi
+else
+    warn "Stage 2 skipped (--skip-analysis)"
+fi
+
+# ── Stage 3: Tests ────────────────────────────────────────────
+stage 3 "Unit & Integration Tests"
+mkdir -p build/results dvt/results
+
+echo "Running unit tests..."
+./build/tests/test_unit.exe \
+    --gtest_output=xml:build/results_unit.xml 2>&1 | tail -5
+cp build/results_unit.xml dvt/results/ 2>/dev/null || true
+pass "Unit tests passed"
+
+echo "Running integration tests..."
+./build/tests/test_integration.exe \
+    --gtest_output=xml:build/results_integration.xml 2>&1 | tail -5
+cp build/results_integration.xml dvt/results/ 2>/dev/null || true
+pass "Integration tests passed"
+
+# ── Stage 4: Coverage ─────────────────────────────────────────
+stage 4 "Code Coverage"
+cmake -S . -B build_cov -G Ninja \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -DBUILD_TESTS=ON \
+    -DENABLE_COVERAGE=ON \
+    -Wno-dev 2>&1 | tail -3
+cmake --build build_cov 2>&1 | tail -3
+
+./build_cov/tests/test_unit.exe --gtest_brief=1 2>&1 | tail -3
+./build_cov/tests/test_integration.exe --gtest_brief=1 2>&1 | tail -3
+
+mkdir -p coverage-report
+GCDA_DIR="build_cov/CMakeFiles/monitor_lib.dir/src"
+GCDA_COUNT=$(find build_cov -name '*.gcda' 2>/dev/null | wc -l)
+echo "Found $GCDA_COUNT .gcda files"
+
+if [ "$GCDA_COUNT" -gt 0 ]; then
+    for gcda in "$GCDA_DIR"/*.gcda; do
+        [ -f "$gcda" ] && gcov -o "$GCDA_DIR" "$gcda" 2>/dev/null
+    done
+
+    # Try gcovr if available
+    if command -v gcovr &>/dev/null; then
+        gcovr --root . --filter 'src/' \
+            --xml coverage-report/coverage.xml \
+            --html-details coverage-report/index.html \
+            --print-summary 2>&1
+        pass "Coverage report generated (gcovr)"
+    else
+        echo "gcovr not installed — using gcov text output"
+        # Parse gcov output with Python
+        python3 -c "
+import glob, os
+total = covered = 0
+for f in sorted(glob.glob('*.gcov')):
+    src = f.replace('.gcov','')
+    if not os.path.exists(os.path.join('src', src)):
+        continue
+    fl = fc = 0
+    for line in open(f):
+        parts = line.split(':', 2)
+        if len(parts) < 3: continue
+        c = parts[0].strip()
+        if c == '-': continue
+        fl += 1
+        if c not in ('#####', '0'): fc += 1
+    total += fl; covered += fc
+    pct = fc/fl*100 if fl else 0
+    print(f'  {src:25s}  {fc:4d}/{fl:4d}  ({pct:.1f}%)')
+pct = covered/total*100 if total else 0
+print(f'\n  TOTAL: {covered}/{total} lines ({pct:.1f}%)')
+"
+        pass "Coverage summary generated (gcov)"
+    fi
+else
+    warn "No .gcda files found — coverage unavailable"
+fi
+
+# ── Stage 5: DVT Report ──────────────────────────────────────
+stage 5 "DVT Report"
+python3 - << 'PYEOF'
+import os, datetime, xml.etree.ElementTree as ET
+
+date_str = datetime.datetime.now().strftime("%Y-%m-%d_%H%M%S")
+report_path = f"dvt/results/dvt_report_{date_str}.txt"
+
+SWR_MAP = {
+    "VitalsTest": "SWR-VIT-001..007", "AlertsTest": "SWR-ALT-001..004",
+    "PatientTest": "SWR-PAT-001..006", "NEWS2Test": "SWR-NEW-001..005",
+    "AlarmLimitsTest": "SWR-ALM-001..006", "TrendTest": "SWR-TRD-001..004",
+    "AuthTest": "SWR-SEC-001..003, SWR-GUI-001..002",
+    "UserManagementTest": "SWR-GUI-007", "LocalizationTest": "SWR-GUI-012",
+    "AppConfigTest": "SWR-GUI-010", "HalTest": "SWR-VIT-008",
+    "MonitoringIntegration": "SWR-VIT + SWR-ALT (end-to-end)",
+    "EscalationIntegration": "SWR-ALT + SWR-NEW (escalation)",
+}
+
+def parse(path):
+    try:
+        root = ET.parse(path).getroot()
+        t = int(root.get("tests", 0))
+        f = int(root.get("failures", 0)) + int(root.get("errors", 0))
+        return t, t - f, f
+    except: return 0, 0, -1
+
+def suites(path):
+    result = []
+    try:
+        for ts in ET.parse(path).getroot().findall('.//testsuite'):
+            t = int(ts.get('tests', 0))
+            f = int(ts.get('failures', 0)) + int(ts.get('errors', 0))
+            result.append((ts.get('name', '?'), t, t - f, f))
+    except: pass
+    return result
+
+# Try both naming conventions
+for u_path in ["dvt/results/results_unit.xml", "build/results_unit.xml"]:
+    if os.path.exists(u_path): break
+for i_path in ["dvt/results/results_integration.xml", "build/results_integration.xml"]:
+    if os.path.exists(i_path): break
+
+u_t, u_p, u_f = parse(u_path)
+i_t, i_p, i_f = parse(i_path)
+overall = "PASS" if (u_f == 0 and i_f == 0) else "FAIL"
+
+lines = [
+    "=" * 80, "  PATIENT VITAL SIGNS MONITOR — DVT REPORT (IEC 62304 Class B)",
+    "=" * 80,
+    f"  Generated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+    "=" * 80, "",
+    "1. TEST RESULTS", "-" * 80,
+    f"  Unit:        {u_p:3d}/{u_t:3d}  {'PASS' if u_f==0 else 'FAIL'}",
+    f"  Integration: {i_p:3d}/{i_t:3d}  {'PASS' if i_f==0 else 'FAIL'}",
+    f"  OVERALL:     {overall}", "",
+    "2. SWR TRACEABILITY", "-" * 80,
+    f"  {'Suite':<28s} {'Tests':>5s} {'Pass':>5s} {'Fail':>5s}  SWR Requirements",
+    "  " + "-" * 76,
+]
+for name, t, p, f in suites(u_path) + suites(i_path):
+    swr = SWR_MAP.get(name, "(unmapped)")
+    lines.append(f"  {name:<28s} {t:5d} {p:5d} {f:5d}  {swr}")
+lines += ["", "3. MANUAL VERIFICATION", "-" * 80,
+    "  SWR-GUI-001..006  GUI layout (structured demo)",
+    "  SWR-GUI-008..011  Window management, persistence",
+    "  IEC 60601-1-8     Alarm display colors", "",
+    "  Protocol: dvt/DVT_Protocol.md (DVT-001-REV-A)",
+    "  Traceability: requirements/TRACEABILITY.md",
+    "=" * 80]
+
+report = "\n".join(lines)
+print(report)
+os.makedirs("dvt/results", exist_ok=True)
+with open(report_path, "w") as f:
+    f.write(report + "\n")
+print(f"\nReport: {report_path}")
+PYEOF
+pass "DVT report generated"
+
+# ── Summary ───────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}════════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  Pipeline complete — all stages passed${NC}"
+echo -e "${GREEN}════════════════════════════════════════════════════════════${NC}"
+echo ""
+echo "  Reports:"
+echo "    dvt/results/dvt_report_*.txt"
+echo "    coverage-report/index.html  (if gcovr installed)"
+echo "    build/results_unit.xml"
+echo "    build/results_integration.xml"


### PR DESCRIPTION
## Summary

### Coverage (stage 4) — fixes 0% issue
- Use `gcov` directly instead of `gcovr` — avoids Windows path issues
- Python script parses `.gcov` output → Cobertura XML + HTML

### DVT (stage 5) — no longer re-runs tests
- Downloads test results from stage 3 — no rebuild, no re-run
- Runs on ubuntu-latest (faster, just report generation)
- Per-suite SWR requirement traceability in report

### Publish reports (stage 6) — runs on PR too
- Runs on BOTH PR and main (was main-only)
- Report uploaded as artifact always
- GitHub Pages deploy only on main

### Local pipeline script
- `scripts/run_pipeline.sh` replicates all 5 stages locally
- `--skip-analysis` flag for faster local runs

### README
- Auto vs manual testing table with SWR mapping

## Change Checklist
- [x] All items reviewed