### PR TITLE
ci: scope all gtest cache keys by repository to unblock pipeline + CodeQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/_deps
-          key: gtest-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-
+          key: gtest-${{ github.repository }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: gtest-${{ github.repository }}-
 
       # ------------------------------------------------------------------
       # 3. Ensure FetchContent can clone GTest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,8 +63,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/_deps
-          key: gtest-codeql-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-codeql-
+          # Scope by repository: build/_deps/*-subbuild/CMakeCache.txt stores
+          # absolute workspace paths, so a cache populated under one repo name
+          # poisons builds under another (e.g. after a repo rename).
+          key: gtest-codeql-${{ github.repository }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: gtest-codeql-${{ github.repository }}-
 
       - name: Build (CodeQL compilation trace)
         shell: bash

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,8 +43,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/_deps
-          key: gtest-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-
+          # Scope by repository: build/_deps/*-subbuild/CMakeCache.txt stores
+          # absolute workspace paths, so a cache populated under one repo name
+          # poisons builds under another (e.g. after a repo rename).
+          key: gtest-${{ github.repository }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: gtest-${{ github.repository }}-
 
       - name: CMake configure
         run: |
@@ -191,8 +194,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: build/_deps
-          key: gtest-codeql-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-codeql-
+          key: gtest-codeql-${{ github.repository }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: gtest-codeql-${{ github.repository }}-
 
       - name: Build (CodeQL compilation trace)
         shell: bash
@@ -225,8 +228,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: build/_deps
-          key: gtest-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-
+          key: gtest-${{ github.repository }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: gtest-${{ github.repository }}-
 
       - name: Build test targets
         run: |
@@ -321,8 +324,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: build_cov/_deps
-          key: gtest-cov-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-cov-
+          key: gtest-cov-${{ github.repository }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: gtest-cov-${{ github.repository }}-
 
       - name: Build with coverage instrumentation
         run: |
@@ -437,8 +440,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: build_dvt/_deps
-          key: gtest-dvt-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: gtest-dvt-
+          key: gtest-dvt-${{ github.repository }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: gtest-dvt-${{ github.repository }}-
 
       - name: Build GUI executable for DVT
         run: |


### PR DESCRIPTION
## Summary
- CodeQL SAST has been failing on every run since the repo rename (#26 on 2026-04-13, #27 on 2026-04-20).
- Root cause: `actions/cache@v4` key in `.github/workflows/codeql.yml` was `gtest-codeql-<hash(CMakeLists.txt)>` with no repo-scoping. CMake `FetchContent` writes absolute workspace paths into `build/_deps/googletest-subbuild/CMakeCache.txt`, so the cache populated under the previous repo name poisoned the build under the new path.
- Fix: include `${{ github.repository }}` in both `key` and `restore-keys`. Invalidates the stale cache once and future-proofs against renames.

The exact CMake error from CodeQL [#27](https://github.com/vinu-dev/medvital-monitor/actions/runs/24650534568):

```
CMake Error: The current CMakeCache.txt directory
D:/a/medvital-monitor/medvital-monitor/build/_deps/googletest-subbuild/CMakeCache.txt
is different than the directory
d:/a/<old-name>/<old-name>/build/_deps/googletest-subbuild
where CMakeCache.txt was created.
```

## Change checklist (per CLAUDE.md)
- [x] User needs — N/A, CI infra only
- [x] System / software requirements — N/A
- [x] README / docs — not affected
- [x] Unit / integration / DVT tests — not affected
- [x] Coverage impact — none
- [x] Release artifact impact — none

## Test plan
- [ ] CodeQL SAST workflow run on this PR completes successfully (validates cache miss → fresh `_deps` populated → CMake configure passes → CodeQL DB built and uploaded)
- [ ] After merge, next scheduled / manual run on `main` reuses the new cache key cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)