### PR TITLE
Gate Agentry roles before LLM runs

### DIFF
--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -4,7 +4,8 @@ agents:
   researcher:
     cli: npx.cmd
     args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
-    interval_min: 60
+    run_on_start: false
+    interval_min: 1440
     total_min: 30
     stall_min: 30
     prompt: |
@@ -17,6 +18,8 @@ agents:
   architect:
     cli: npx.cmd
     args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      issue_labels: ["ready-for-design"]
     interval_min: 10
     total_min: 30
     stall_min: 30
@@ -31,6 +34,8 @@ agents:
   implementer:
     cli: npx.cmd
     args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      issue_labels: ["ready-for-implementation", "tests-failed"]
     interval_min: 10
     total_min: 60
     stall_min: 60
@@ -46,6 +51,8 @@ agents:
   tester:
     cli: npx.cmd
     args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      issue_labels: ["ready-for-test"]
     interval_min: 10
     total_min: 45
     stall_min: 45
@@ -59,6 +66,8 @@ agents:
   reviewer:
     cli: npx.cmd
     args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      pr_labels: ["ready-for-review"]
     interval_min: 10
     total_min: 30
     stall_min: 30
@@ -72,6 +81,8 @@ agents:
   release:
     cli: npx.cmd
     args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      issue_labels: ["release-approved"]
     interval_min: 1440
     total_min: 60
     stall_min: 60

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -26,8 +26,9 @@ $ErrorActionPreference = 'Stop'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
+$InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '2d199daf8e337f5c9db05ccee84876a8af65cd4d'
+$AgentryRef = '123645478367652c5a513e4a5c45e51c2da78c7c'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 $python = $null
@@ -50,13 +51,21 @@ if (-not (Test-Path (Join-Path $Venv 'Scripts\python.exe'))) {
         exit 1
     }
     & (Join-Path $Venv 'Scripts\python.exe') -m pip install --upgrade pip
+}
+
+$InstalledRef = ''
+if (Test-Path $InstallRefFile) {
+    $InstalledRef = (Get-Content $InstallRefFile -Raw).Trim()
+}
+if ($InstalledRef -ne $AgentryRef) {
     Write-Host "==> Installing agentry from GitHub at $AgentryRef" -ForegroundColor Cyan
-    & (Join-Path $Venv 'Scripts\python.exe') -m pip install "git+$AgentryRepo@$AgentryRef"
+    & (Join-Path $Venv 'Scripts\python.exe') -m pip install --upgrade --force-reinstall "git+$AgentryRepo@$AgentryRef"
     if ($LASTEXITCODE -ne 0) {
         Write-Host "agentry install failed" -ForegroundColor Red
         exit 1
     }
-    Write-Host "==> Setup complete" -ForegroundColor Green
+    Set-Content -Path $InstallRefFile -Value $AgentryRef -Encoding ASCII
+    Write-Host "==> Agentry install complete" -ForegroundColor Green
 }
 
 $AgentryExe = Join-Path $Venv 'Scripts\agentry.exe'

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -13,8 +13,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
+INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-2d199daf8e337f5c9db05ccee84876a8af65cd4d}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-123645478367652c5a513e4a5c45e51c2da78c7c}"
 
 PYTHON=""
 for name in python3 python; do
@@ -34,9 +35,17 @@ if [[ ! -x "$VENV/bin/python" ]]; then
     echo "==> First-time setup: creating venv at $VENV"
     "$PYTHON" -m venv "$VENV"
     "$VENV/bin/python" -m pip install --upgrade pip
+fi
+
+INSTALLED_REF=""
+if [[ -f "$INSTALL_REF_FILE" ]]; then
+    INSTALLED_REF="$(tr -d '[:space:]' < "$INSTALL_REF_FILE")"
+fi
+if [[ "$INSTALLED_REF" != "$AGENTRY_REF" ]]; then
     echo "==> Installing agentry from GitHub at $AGENTRY_REF"
-    "$VENV/bin/python" -m pip install "git+$AGENTRY_REPO@$AGENTRY_REF"
-    echo "==> Setup complete"
+    "$VENV/bin/python" -m pip install --upgrade --force-reinstall "git+$AGENTRY_REPO@$AGENTRY_REF"
+    printf '%s\n' "$AGENTRY_REF" > "$INSTALL_REF_FILE"
+    echo "==> Agentry install complete"
 fi
 
 if [[ ! -x "$VENV/bin/agentry" ]]; then


### PR DESCRIPTION
## Summary
- pin target Agentry bootstrap to platform commit `1236454`
- make target start scripts reinstall Agentry when the pinned ref changes
- add trigger gates for Architect, Implementer, Tester, Reviewer, and Release
- defer Researcher startup and reduce discovery cadence to daily

## Why
This keeps the medvital Agentry setup self-sustaining without waking every Codex role on startup. Roles now spend tokens only when the matching GitHub issue or PR label exists.

## Validation
- loaded `agentry/config.yml` with Agentry source from `D:\Codex\AGX-1\src`
- `python -m agentry doctor --target D:\Codex\medvital-monitor`
