### PR TITLE
Fix Agentry install ref pin

### DIFF
--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -28,7 +28,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '123645478367652c5a513e4a5c45e51c2da78c7c'
+$AgentryRef = '1236454e941a99c6dcb0a5a3b4607eaf50b95b5f'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 $python = $null

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-123645478367652c5a513e4a5c45e51c2da78c7c}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-1236454e941a99c6dcb0a5a3b4607eaf50b95b5f}"
 
 PYTHON=""
 for name in python3 python; do


### PR DESCRIPTION
## Summary
- fix medvital Agentry start scripts to use the valid full Agentry main SHA

## Validation
- verified SHA via `git ls-remote https://github.com/vinu-dev/agentry.git refs/heads/main`
- parsed `agentry/start.ps1`
