### PR TITLE
Pin Agentry worktree isolation

### DIFF
--- a/agentry/.gitignore
+++ b/agentry/.gitignore
@@ -3,3 +3,4 @@
 .venv/
 logs/
 state/
+worktrees/

--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -1,4 +1,5 @@
 target_repo: vinu-dev/medvital-monitor
+isolate_worktrees: true
 
 agents:
   researcher:

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -28,7 +28,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '1236454e941a99c6dcb0a5a3b4607eaf50b95b5f'
+$AgentryRef = '269ec37ff8d635499fac1ac4e4738c5e33a9fb8d'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 $python = $null

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-1236454e941a99c6dcb0a5a3b4607eaf50b95b5f}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-269ec37ff8d635499fac1ac4e4738c5e33a9fb8d}"
 
 PYTHON=""
 for name in python3 python; do


### PR DESCRIPTION
## Summary
- pin Medvital Agentry start scripts to Agentry main commit 269ec37
- explicitly enable per-role worktree isolation
- ignore Agentry worktree runtime folders

## Tests
- Not run; config/script pin only.