### PR TITLE
Assign Codex models by Agentry role

### DIFF
--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -4,7 +4,7 @@ isolate_worktrees: true
 agents:
   researcher:
     cli: npx.cmd
-    args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4-mini", "--dangerously-bypass-approvals-and-sandbox"]
     run_on_start: false
     interval_min: 1440
     total_min: 30
@@ -18,7 +18,7 @@ agents:
 
   architect:
     cli: npx.cmd
-    args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox"]
     trigger:
       issue_labels: ["ready-for-design"]
     interval_min: 10
@@ -34,7 +34,7 @@ agents:
 
   implementer:
     cli: npx.cmd
-    args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox"]
     trigger:
       issue_labels: ["ready-for-implementation", "tests-failed"]
     interval_min: 10
@@ -51,7 +51,7 @@ agents:
 
   tester:
     cli: npx.cmd
-    args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4-mini", "--dangerously-bypass-approvals-and-sandbox"]
     trigger:
       issue_labels: ["ready-for-test"]
     interval_min: 10
@@ -66,7 +66,7 @@ agents:
 
   reviewer:
     cli: npx.cmd
-    args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox"]
     trigger:
       pr_labels: ["ready-for-review"]
     interval_min: 10
@@ -81,7 +81,7 @@ agents:
 
   release:
     cli: npx.cmd
-    args: ["--yes", "@openai/codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4-mini", "--dangerously-bypass-approvals-and-sandbox"]
     trigger:
       issue_labels: ["release-approved"]
     interval_min: 1440


### PR DESCRIPTION
## Summary
- set explicit Codex model args for every Agentry role
- use gpt-5.4-mini for lower-risk research, test, and release smoke roles
- keep gpt-5.4 for architecture, implementation, and review decisions

## Tests
- agentry doctor --target D:\\Codex\\medvital-monitor