### PR TITLE
Pin latest Agentry model tier defaults

### DIFF
--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -28,7 +28,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '269ec37ff8d635499fac1ac4e4738c5e33a9fb8d'
+$AgentryRef = '64d63115165bbd346c631c8f96d44a098090d1f0'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 $python = $null

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-269ec37ff8d635499fac1ac4e4738c5e33a9fb8d}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-64d63115165bbd346c631c8f96d44a098090d1f0}"
 
 PYTHON=""
 for name in python3 python; do


### PR DESCRIPTION
## Summary
- update Medvital Agentry start scripts to install Agentry main commit 64d6311
- keeps the target pinned to the platform version that includes role model-tier defaults

## Tests
- agentry doctor --target D:\\Codex\\medvital-monitor