### PR TITLE
Pin Agentry reviewer approval fallback

### DIFF
--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -63,9 +63,9 @@ agents:
       Process the oldest open issue labeled `ready-for-test`. Rebase the shared feature branch,
       inspect changed files, run the matching validation rows, and record exact commands and
       results. If green, reuse any existing open PR for the feature branch or open one if needed,
-      label it `ready-for-review`, remove `blocked` from that PR, remove `ready-for-test` from
-      the issue, and comment with the PR URL; if red, label the issue `tests-failed` with trimmed
-      failure output. Never suppress or lower tests.
+      label it `ready-for-review`, remove stale `blocked` and `agent-approved` labels from that
+      PR, remove `ready-for-test` from the issue, and comment with the PR URL; if red, label the
+      issue `tests-failed` with trimmed failure output. Never suppress or lower tests.
 
   reviewer:
     cli: npx.cmd
@@ -80,10 +80,11 @@ agents:
       Review the oldest PR labeled `ready-for-review`. Check issue, spec, diff, tests,
       requirements traceability, sensitive paths, security, and medical-safety impact.
       Approve only if the work is scoped, validated, and traceable. Request changes for
-      any safety, auth, CI, traceability, or release-risk gap. If approval succeeds, remove
-      `ready-for-review` and `blocked` from the PR. If changes are needed, remove
-      `ready-for-review`, add `blocked` to the PR, move the linked issue to `changes-requested`,
-      and comment with the exact findings. Never merge.
+      any safety, auth, CI, traceability, or release-risk gap. If approval succeeds, add
+      `agent-approved`, remove `ready-for-review` and `blocked` from the PR, and comment with
+      the approval outcome if GitHub refuses formal self-review. If changes are needed, remove
+      `agent-approved` and `ready-for-review`, add `blocked` to the PR, move the linked issue to
+      `changes-requested`, and comment with the exact findings. Never merge.
 
   release:
     cli: npx.cmd

--- a/agentry/start.ps1
+++ b/agentry/start.ps1
@@ -28,7 +28,7 @@ $TargetRoot = Split-Path -Parent $ScriptDir
 $Venv = Join-Path $ScriptDir '.venv'
 $InstallRefFile = Join-Path $Venv '.agentry-install-ref'
 $AgentryRepo = 'https://github.com/vinu-dev/agentry.git'
-$AgentryRef = '266559e3a1cffc96b7a8a4a24192fdda3e3dedb3'
+$AgentryRef = 'f6e9bf6d369cb5dee3b03bf53c3985603c02c289'
 if ($env:AGENTRY_INSTALL_REF) { $AgentryRef = $env:AGENTRY_INSTALL_REF }
 
 $python = $null

--- a/agentry/start.sh
+++ b/agentry/start.sh
@@ -15,7 +15,7 @@ TARGET_ROOT="$(dirname "$SCRIPT_DIR")"
 VENV="$SCRIPT_DIR/.venv"
 INSTALL_REF_FILE="$VENV/.agentry-install-ref"
 AGENTRY_REPO="https://github.com/vinu-dev/agentry.git"
-AGENTRY_REF="${AGENTRY_INSTALL_REF:-266559e3a1cffc96b7a8a4a24192fdda3e3dedb3}"
+AGENTRY_REF="${AGENTRY_INSTALL_REF:-f6e9bf6d369cb5dee3b03bf53c3985603c02c289}"
 
 PYTHON=""
 for name in python3 python; do

--- a/docs/ai/roles/reviewer.md
+++ b/docs/ai/roles/reviewer.md
@@ -41,3 +41,13 @@ Approve only if:
 - Any clinical-behavior change has human-approved acceptance criteria.
 
 Never merge. Human code-owner approval and merge remain separate.
+
+## Writeback Rules
+
+- If GitHub accepts a formal review, use it.
+- If GitHub refuses owner/self-review, post a PR comment beginning
+  `Agentry review outcome: APPROVED` or `Agentry review outcome: REQUEST CHANGES`.
+- Approved PRs must have `agent-approved` and must not have `ready-for-review`
+  or `blocked`.
+- Request-changes PRs must not have `agent-approved`; they must have `blocked`,
+  and the linked issue must move to `changes-requested`.


### PR DESCRIPTION
## Summary
- pin Agentry to the reviewer approval fallback fix
- teach the target reviewer/tester prompts to use `agent-approved` as the fallback approval signal
- document Medvital reviewer writeback rules for owner/self-review cases

## Tests
- not run; target config/docs only