### PR TITLE
Traceability: refresh SWR GUI auth verification references

### DIFF
--- a/docs/history/risk/28-traceability-refresh-swr-gui-auth-verification-references.md
+++ b/docs/history/risk/28-traceability-refresh-swr-gui-auth-verification-references.md
@@ -1,0 +1,110 @@
+## Risk Note: Issue 28
+
+Issue: `#28`  
+Branch: `feature/28-traceability-refresh-swr-gui-auth-verification-references`
+
+## proposed change
+
+Update the verification text in `requirements/SWR.md` for the GUI
+authentication and GUI display requirements so it matches the current approved
+traceability evidence. The intended scope is documentation and evidence
+reconciliation only:
+
+- `SWR-GUI-001` should cite the current `tests/unit/test_auth.cpp` evidence
+  names `UsersTest.REQ_GUI_001_*` instead of stale `AuthValidation.*`.
+- `SWR-GUI-002` should cite `UsersTest.REQ_GUI_002_*` instead of stale
+  `AuthDisplayName.*`.
+- `SWR-GUI-003` should stop claiming structural verification by
+  `AuthValidation.*` and align with the RTM's GUI-demonstration evidence for
+  colour-tile and banner painting behavior.
+
+No production code, test logic, credentials, session flow, or GUI rendering
+behavior should change.
+
+## medical-safety impact
+
+No direct runtime, clinical-threshold, alerting, NEWS2, patient-record, or
+device-integration behavior change is proposed. The safety impact is indirect
+but real: stale or overstated verification references can cause reviewers to
+misjudge which authentication and GUI behaviors are actually covered by
+automated evidence versus manual GUI evidence. That weakens change-impact review
+and audit confidence, but it does not itself change bedside behavior. Overall
+medical-safety impact is low if implementation remains documentation-only.
+
+## security and privacy impact
+
+No security-control behavior change is intended. Authentication, credential
+storage, role enforcement, and logout behavior remain in scope only as evidence
+references, not as code changes. The main security concern is integrity of the
+verification record: inaccurate auth evidence could mislead reviewers about what
+login and session behavior is actually tested. Privacy impact is none expected
+because no patient-data collection, persistence, export, or access path changes
+are requested.
+
+## affected requirements or "none"
+
+- `SWR-GUI-001`
+- `SWR-GUI-002`
+- `SWR-GUI-003`
+
+These are affected only in their verification-text references. The underlying
+`SYS-013` and `SYS-014` behavioral intent should remain unchanged.
+
+## hazards and failure modes
+
+- Reviewers follow stale suite names that no longer represent the approved auth
+  evidence and conclude the repository lacks traceable verification.
+- Documentation overstates automated evidence by implying auth unit tests
+  structurally verify GUI tile and banner painting behavior.
+- An implementer expands a documentation fix into auth, session-management, or
+  GUI-rendering code changes to make stale references appear true.
+- SWR text and RTM rows diverge again, leaving conflicting evidence claims for
+  the same requirements.
+
+## existing controls
+
+- The issue body explicitly states there is no runtime or clinical behavior
+  change.
+- `requirements/TRACEABILITY.md` already maps `SWR-GUI-001` to
+  `UsersTest.REQ_GUI_001_*`, `SWR-GUI-002` to `UsersTest.REQ_GUI_002_*`, and
+  `SWR-GUI-003` to GUI-demo evidence.
+- `tests/unit/test_auth.cpp` contains the actual approved GUI-auth evidence IDs
+  and shows that `AuthValidation.*` / `AuthDisplayName.*` are stale names.
+- The architecture separates GUI auth and presentation concerns from the
+  clinically relevant domain logic, limiting patient-facing impact if scope is
+  contained.
+
+## required design controls
+
+- Restrict implementation to requirements and traceability documentation; do not
+  modify `src/**`, `include/**`, `tests/**`, or release artifacts for this
+  issue.
+- Treat `requirements/TRACEABILITY.md` and `tests/unit/test_auth.cpp` as the
+  canonical evidence sources when updating `requirements/SWR.md`.
+- Preserve `SWR-GUI-003` as GUI-demonstration evidence unless a human owner
+  explicitly approves new automated GUI verification.
+- Review the changed file list and diff to confirm the implementation stays
+  documentation-only and does not alter authentication semantics or GUI logic.
+- Keep implementation notes explicit that this is evidence reconciliation for
+  existing approved behavior, not a redefinition of the auth or GUI
+  requirements themselves.
+
+## validation expectations
+
+- Run the issue's targeted text searches and confirm `requirements/SWR.md`,
+  `requirements/TRACEABILITY.md`, and `tests/unit/test_auth.cpp` agree on the
+  current evidence names for `SWR-GUI-001` and `SWR-GUI-002`.
+- Confirm `SWR-GUI-003` no longer claims `AuthValidation.*` as structural
+  evidence and remains aligned to GUI-demonstration verification.
+- Inspect the changed file list and diff during implementation to verify
+  documentation-only scope.
+- No product test rerun is required for this risk conclusion because executable
+  behavior is unchanged; the relevant validation is evidence consistency across
+  approved documentation and the existing test suite.
+
+## residual risk for this pilot
+
+Low. Residual risk is limited to human documentation transcription error or a
+missed stale reference, not to patient-facing behavior. With the controls
+above, this issue is appropriate to move forward as a low-risk
+traceability/evidence-correction item.

--- a/docs/history/specs/28-traceability-refresh-swr-gui-auth-verification-references.md
+++ b/docs/history/specs/28-traceability-refresh-swr-gui-auth-verification-references.md
@@ -1,0 +1,152 @@
+# Design Spec: Issue 28
+
+Issue: `#28`  
+Branch: `feature/28-traceability-refresh-swr-gui-auth-verification-references`  
+Spec path: `docs/history/specs/28-traceability-refresh-swr-gui-auth-verification-references.md`
+
+## Problem
+
+`requirements/SWR.md` still cites stale or unsupported verification evidence for
+three GUI/authentication requirements:
+
+- `SWR-GUI-001` still names `AuthValidation.*`, but the approved auth unit tests
+  in `tests/unit/test_auth.cpp` use the `UsersTest.REQ_GUI_001_*` pattern.
+- `SWR-GUI-002` still names `AuthDisplayName.*`, but the approved auth unit
+  tests use `UsersTest.REQ_GUI_002_*`.
+- `SWR-GUI-003` claims structural verification by `AuthValidation.*`, even
+  though those auth tests do not exercise GUI tile painting or banner repaint
+  behavior.
+
+`requirements/TRACEABILITY.md` and `tests/unit/test_auth.cpp` already reflect
+the current evidence names, so the mismatch is in the SWR document rather than
+in product code or test implementation. That weakens audit confidence and
+change-impact review for authentication and GUI evidence.
+
+## Goal
+
+Reconcile the SWR verification text for `SWR-GUI-001`, `SWR-GUI-002`, and
+`SWR-GUI-003` so it matches the approved evidence already present in
+`requirements/TRACEABILITY.md` and `tests/unit/test_auth.cpp`, without changing
+runtime behavior.
+
+## Non-goals
+
+- Changing authentication logic, credential handling, session management, or
+  logout behavior.
+- Changing GUI painting, color mapping, repaint triggers, or dashboard layout.
+- Adding new automated GUI tests, new requirement IDs, or new traceability
+  claims beyond the existing approved evidence.
+- Editing `src/**`, `include/**`, `tests/**`, CI workflows, or release
+  artifacts for this issue.
+- Reworking SYS-level intent for `SYS-013` or `SYS-014`.
+
+## Current Behavior
+
+- `requirements/SWR.md` currently documents stale `Verified by:` text for
+  `SWR-GUI-001` and `SWR-GUI-002`, and an overstated structural-verification
+  claim for `SWR-GUI-003`.
+- `tests/unit/test_auth.cpp` defines the current auth evidence as:
+  - `UsersTest.REQ_GUI_001_*` for `auth_validate()` behavior.
+  - `UsersTest.REQ_GUI_002_*` for `auth_display_name()`-related behavior.
+- `requirements/TRACEABILITY.md` already maps:
+  - `SWR-GUI-001` to `UsersTest.REQ_GUI_001_*`.
+  - `SWR-GUI-002` to `UsersTest.REQ_GUI_002_*`.
+  - `SWR-GUI-003` to GUI demonstration evidence rather than auth unit tests.
+- `src/gui_auth.c` and `src/gui_main.c` already implement the approved auth and
+  GUI behaviors; this issue is about evidence wording only.
+
+## Proposed Change
+
+1. Update the `Verified by:` line for `SWR-GUI-001` in `requirements/SWR.md`
+   from the stale `AuthValidation.*` label to
+   `UsersTest.REQ_GUI_001_*`.
+2. Update the `Verified by:` line for `SWR-GUI-002` from the stale
+   `AuthDisplayName.*` label to `UsersTest.REQ_GUI_002_*`.
+3. Update the `Verified by:` text for `SWR-GUI-003` so it no longer claims
+   structural verification by auth unit tests and instead aligns to GUI
+   demonstration/manual evidence already described in the RTM.
+4. Keep the requirement statements, `Traces to:` mappings, and `Implemented in:`
+   references unchanged unless a strictly local wording fix inside
+   `requirements/SWR.md` is needed to avoid ambiguity.
+5. If the repository process requires document metadata or revision-history
+   maintenance for an SWR edit, keep that change confined to
+   `requirements/SWR.md` and do not expand scope into unrelated traceability
+   artifacts.
+
+## Files Expected To Change
+
+Expected implementation file:
+
+- `requirements/SWR.md`
+
+Files expected not to change for this issue:
+
+- `requirements/TRACEABILITY.md`
+- `tests/unit/test_auth.cpp`
+- `src/gui_auth.c`
+- `src/gui_main.c`
+- Any other production, test, CI, or release file
+
+## Requirements And Traceability Impact
+
+- Affected SWR entries:
+  - `SWR-GUI-001`
+  - `SWR-GUI-002`
+  - `SWR-GUI-003`
+- Related higher-level requirements remain unchanged:
+  - `SYS-013`
+  - `SYS-014`
+- This is a traceability and verification-evidence correction for existing
+  approved behavior, not a behavior change.
+- No new SWR IDs, SYS IDs, test cases, or acceptance criteria should be
+  introduced.
+- Because the issue touches authentication and traceability wording, the final
+  implementation review should explicitly confirm that documentation claims do
+  not overstate automated evidence for GUI presentation behavior.
+
+## Medical-Safety, Security, And Privacy Impact
+
+- Medical safety: indirect positive impact only. Correct evidence mapping makes
+  review of approved authentication and GUI requirements more trustworthy, but
+  does not alter clinical thresholds, alerting, NEWS2, device I/O, or patient
+  workflow behavior.
+- Security: no intended control change. Authentication, password storage, role
+  enforcement, and logout flows remain untouched; only their verification
+  references are corrected.
+- Privacy: no intended impact. No patient-data collection, persistence, access,
+  or export path changes.
+
+## Validation Plan
+
+Use targeted text validation rather than full product test reruns:
+
+```powershell
+rg -n "SWR-GUI-001|SWR-GUI-002|SWR-GUI-003|Verified by:" requirements/SWR.md
+rg -n "REQ_GUI_001|REQ_GUI_002|AuthValidation|AuthDisplayName" tests/unit/test_auth.cpp requirements/TRACEABILITY.md
+git diff --name-only
+git diff -- requirements/SWR.md
+```
+
+Expected validation outcome:
+
+- `requirements/SWR.md` cites `UsersTest.REQ_GUI_001_*` for `SWR-GUI-001`.
+- `requirements/SWR.md` cites `UsersTest.REQ_GUI_002_*` for `SWR-GUI-002`.
+- `requirements/SWR.md` no longer claims `AuthValidation.*` structurally
+  verifies `SWR-GUI-003`.
+- The changed file list remains documentation-only.
+
+No executable behavior change is expected, so routine unit/integration reruns
+are not required unless the implementer discovers an unrelated discrepancy.
+
+## Rollback Or Failure Handling
+
+- If implementation-time inspection shows that `requirements/TRACEABILITY.md` or
+  `tests/unit/test_auth.cpp` no longer represent the approved canonical
+  evidence, stop and re-evaluate scope before editing multiple traceability
+  artifacts.
+- If reconciling `SWR-GUI-003` requires inventing new automated evidence, do
+  not proceed under this issue; leave GUI-demo evidence in place and escalate a
+  follow-on test-design issue instead.
+- Rollback is straightforward because the intended implementation is limited to
+  SWR documentation: revert the `requirements/SWR.md` change and restore the
+  prior evidence wording if necessary.

--- a/requirements/SWR.md
+++ b/requirements/SWR.md
@@ -300,7 +300,7 @@ It shall return `0` for any other input, including empty strings and NULL
 pointers. NULL inputs shall not cause undefined behaviour.
 **Traces to:** SYS-013
 **Implemented in:** `src/gui_auth.c` — `auth_validate()`
-**Verified by:** `tests/unit/test_auth.cpp` — `AuthValidation.*`
+**Verified by:** `tests/unit/test_auth.cpp` — `UsersTest.REQ_GUI_001_*`
 
 ---
 
@@ -318,7 +318,7 @@ pointers. NULL inputs shall not cause undefined behaviour.
 **Traces to:** SYS-013
 **Implemented in:** `src/gui_main.c` — `attempt_login()`, `login_proc()`,
 `dash_proc()` (IDC_BTN_LOGOUT handler)
-**Verified by:** `tests/unit/test_auth.cpp` — `AuthDisplayName.*`
+**Verified by:** `tests/unit/test_auth.cpp` — `UsersTest.REQ_GUI_002_*`
 
 ---
 
@@ -336,8 +336,7 @@ All tiles and the banner shall repaint automatically each time
 **Traces to:** SYS-014, SYS-005, SYS-006
 **Implemented in:** `src/gui_main.c` — `paint_tile()`, `paint_tiles()`,
 `paint_status_banner()`, `update_dashboard()`
-**Verified by:** Verified structurally by `AuthValidation.*`; visual
-verification performed via GUI demonstration.
+**Verified by:** GUI demonstration.
 
 ---
 
@@ -662,3 +661,4 @@ and language selector population; `src/app_config.c` -
 | G   | 2026-04-08 | claude          | Added SWR-GUI-011 (rolling message in simulation mode) — v2.7.0 |
 | H   | 2026-05-03 | codex           | Reconciled SWR-VIT-008 and SWR-NEW-001 to existing alerting and aggregate-risk SYS links; no clinical behavior changes |
 | I   | 2026-05-03 | Codex implementer | Added SWR-GUI-012 (localization selection and persistence) |
+| J   | 2026-05-05 | vinu           | Refreshed SWR-GUI-001..003 verification references |


### PR DESCRIPTION
## Summary
- refresh `SWR-GUI-001` verification evidence to `UsersTest.REQ_GUI_001_*`
- refresh `SWR-GUI-002` verification evidence to `UsersTest.REQ_GUI_002_*`
- align `SWR-GUI-003` verification text to GUI demonstration evidence
- record the SWR document revision entry for this traceability refresh

## Validation
- `rg -n "SWR-GUI-001|SWR-GUI-002|SWR-GUI-003|Verified by:" requirements/SWR.md`
- `rg -n "REQ_GUI_001|REQ_GUI_002|AuthValidation|AuthDisplayName" tests/unit/test_auth.cpp requirements/TRACEABILITY.md`
- `git diff --name-only`

Closes #28
