### PR TITLE
[codex] Add AI safety audit gate to medical roles

### DIFF
--- a/agentry/config.yml
+++ b/agentry/config.yml
@@ -82,6 +82,7 @@ agents:
         - "quality-issues"
         - "cyber-issues"
         - "regulatory-issues"
+        - "ai-safety-issues"
         - "traceability-broken"
         - "ready-for-implementation"
     interval_min: 10
@@ -92,7 +93,7 @@ agents:
       You are the Implementer for this repository. Read docs/ai/roles/implementer.md first.
       If the Agentry Work Packet names a Selected Candidate, process that issue only. Otherwise process
       retry labels first (`changes-requested`, `tests-failed`, `quality-issues`, `cyber-issues`,
-      `regulatory-issues`, `traceability-broken`) before `ready-for-implementation`.
+      `regulatory-issues`, `ai-safety-issues`, `traceability-broken`) before `ready-for-implementation`.
       Use the existing feature/<issue>-<slug> branch, rebase on origin/main, read the risk note and spec,
       implement only the approved scope, update tests and traceability when required, run relevant
       validation, commit explicit paths only, push with --force-with-lease, and move the issue to
@@ -183,8 +184,27 @@ agents:
       You are the Regulatory Reviewer for this medical-software pilot. Read docs/ai/roles/regulatory_reviewer.md first.
       This is an intermediate gate: do not add `agent-approved`. Assess whether the change affects intended
       use, clinical claims, risk controls, release evidence, or simulated-device regulatory documentation.
-      If good, move the PR to `ready-for-traceability`; if not, add `regulatory-issues`, move the linked
-      issue to `regulatory-issues`, and comment with exact gaps.
+      If good, move the PR to `ready-for-ai-safety-review`; if not, add `regulatory-issues`, move the
+      linked issue to `regulatory-issues`, and comment with exact gaps.
+
+  ai_safety_reviewer:
+    cli: npx.cmd
+    args: ["--yes", "@openai/codex", "exec", "-m", "gpt-5.4", "--dangerously-bypass-approvals-and-sandbox"]
+    trigger:
+      pr_labels: ["ready-for-ai-safety-review"]
+      pr_check_gate: settled
+    interval_min: 10
+    total_min: 45
+    stall_min: 45
+    token_budget: 40000
+    prompt: |
+      You are the AI Safety Reviewer for this medical-software pilot. Read docs/ai/roles/ai_safety_reviewer.md first.
+      This is an intermediate gate: do not add `agent-approved`. Classify whether the PR adds, changes,
+      removes, or depends on an AI-enabled device software function. For AI/ML changes, require intended
+      use, model/data provenance, dataset split, bias/subgroup analysis, transparency/user information,
+      human-in-the-loop limits, locked model/versioning, performance monitoring, and PCCP impact analysis.
+      If no AI/ML function is affected, say so explicitly. If good, move the PR to `ready-for-traceability`;
+      if not, add `ai-safety-issues`, move the linked issue to `ai-safety-issues`, and comment with exact gaps.
 
   traceability_tracker:
     cli: npx.cmd
@@ -247,6 +267,7 @@ labels:
   ready-for-quality-review: ready-for-quality-review
   ready-for-cyber-review: ready-for-cyber-review
   ready-for-regulatory-review: ready-for-regulatory-review
+  ready-for-ai-safety-review: ready-for-ai-safety-review
   ready-for-traceability: ready-for-traceability
   ready-for-merge: ready-for-merge
   ready-for-review: ready-for-review
@@ -261,6 +282,7 @@ labels:
   quality-issues: quality-issues
   cyber-issues: cyber-issues
   regulatory-issues: regulatory-issues
+  ai-safety-issues: ai-safety-issues
   traceability-broken: traceability-broken
 
 merge_sensitive_paths:

--- a/docs/ai/agentry-medical-pilot.md
+++ b/docs/ai/agentry-medical-pilot.md
@@ -24,6 +24,8 @@ researcher
   -> cybersecurity_reviewer
   -> ready-for-regulatory-review
   -> regulatory_reviewer
+  -> ready-for-ai-safety-review
+  -> ai_safety_reviewer
   -> ready-for-traceability
   -> traceability_tracker
   -> ready-for-merge
@@ -46,6 +48,9 @@ only after the full path is proven.
 - Tester PR bodies must start with `Closes #<issue>` so GitHub closes issues on
   merge.
 - Intermediate reviewers do not add `agent-approved`.
+- AI Safety Reviewer explicitly classifies whether AI/ML is affected. AI/ML
+  changes need data/model provenance, bias and subgroup evidence, transparency,
+  monitoring, and PCCP/change-control rationale before traceability review.
 - Traceability Tracker is the final approval gate and adds `agent-approved` plus
   `ready-for-merge`.
 - Merger merges only green, mergeable PRs with `ready-for-merge` and
@@ -61,3 +66,4 @@ only after the full path is proven.
 - GitHub label transitions and PR comments
 - local and GitHub validation results
 - token use per role
+- AI/ML not-applicable rationale or AI safety evidence bundle when applicable

--- a/docs/ai/roles/ai_safety_reviewer.md
+++ b/docs/ai/roles/ai_safety_reviewer.md
@@ -1,0 +1,78 @@
+# AI Safety Reviewer Role
+
+## Mission
+
+Provide the AI-enabled device software function gate before final traceability
+review. This role decides whether a PR is outside AI/ML scope or has enough
+evidence to support an FDA-style audit trail for AI/ML lifecycle, transparency,
+bias, monitoring, and change control.
+
+This is an intermediate gate. Do not add `agent-approved`.
+
+## Trigger
+
+Process one PR labeled `ready-for-ai-safety-review`. If the Agentry Work Packet
+names a `Selected Candidate`, review only that PR.
+
+## Required Inputs
+
+Read:
+
+- linked issue
+- risk note under `docs/history/risk/`
+- design spec under `docs/history/specs/`
+- PR body, changed-file list, and CI state
+- Code, Quality, Cybersecurity, and Regulatory review comments
+- relevant requirements and traceability files
+
+## Classification
+
+First classify the PR:
+
+- `AI/ML not affected`: no AI-enabled device software function is added,
+  changed, removed, or depended on.
+- `AI/ML affected`: the PR adds, changes, removes, or depends on AI/ML,
+  adaptive logic, learned models, model-derived thresholds, model monitoring,
+  model data, or AI-generated clinical/user-facing outputs.
+
+If AI/ML is not affected, say so explicitly and move the PR to
+`ready-for-traceability`.
+
+## AI/ML Evidence Checklist
+
+For AI/ML affected PRs, verify:
+
+- intended use, user population, operating environment, and clinical workflow
+  boundaries
+- model purpose, inputs, outputs, locked model/version, and whether the model is
+  adaptive or fixed
+- training, tuning, validation, and test data provenance, including any
+  exclusion criteria or data-quality limitations
+- objective performance metrics, acceptance criteria, confidence/uncertainty
+  handling, and failure modes
+- subgroup, bias, representativeness, and known limitation analysis
+- human-in-the-loop expectations, user override/confirmation behavior, and
+  circumstances where the output must not be used
+- transparency/user-information text explaining model purpose, limitations,
+  uncertainty, and clinically relevant warnings
+- cybersecurity/privacy impact for model files, data flows, logs, update paths,
+  and dependency/SBOM changes
+- performance monitoring plan, including drift/performance degradation signals,
+  complaint/incident handling, and retraining/change triggers
+- PCCP or change-control decision: whether future model/data/performance
+  changes are in scope, out of scope, or require human regulatory review
+- traceability from AI/ML requirements to risk controls, code/model artifacts,
+  tests, DVT/manual evidence, and monitoring evidence
+
+## Output
+
+- Pass: comment `AI safety review outcome: PASSED`, remove
+  `ready-for-ai-safety-review`, add `ready-for-traceability`, and verify labels.
+- Not applicable: comment `AI safety review outcome: NOT APPLICABLE` with the
+  file-based rationale, remove `ready-for-ai-safety-review`, add
+  `ready-for-traceability`, and verify labels.
+- Fail: comment `AI safety review outcome: ISSUES FOUND` with exact missing
+  evidence, remove `ready-for-ai-safety-review`, add `ai-safety-issues`, move
+  the linked issue to `ai-safety-issues`, and keep `pr-open`.
+
+Never merge.

--- a/docs/ai/roles/architect.md
+++ b/docs/ai/roles/architect.md
@@ -41,11 +41,17 @@ Each spec must include:
 - Problem
 - Goal
 - Non-goals
+- Intended use impact, user population, operating environment, and foreseeable
+  misuse
 - Current behavior
 - Proposed change
 - Files expected to change
 - Requirements and traceability impact
 - Medical-safety, security, and privacy impact
+- AI/ML impact assessment: state whether the change adds, changes, removes, or
+  depends on an AI-enabled device software function. If yes, describe model
+  purpose, input data, output, human-in-the-loop limits, transparency needs,
+  dataset and bias considerations, monitoring expectations, and PCCP impact.
 - Validation plan
 - Rollback or failure handling
 
@@ -55,6 +61,8 @@ Each spec must include:
   persistence, CI, release, requirements, or traceability must call that out.
 - Clinical behavior changes require explicit issue acceptance criteria from the
   human owner.
+- AI/ML behavior changes require explicit risk-note coverage and human-approved
+  acceptance criteria before implementation.
 - If the issue is too broad, comment with the split proposal and leave it in
   `ready-for-design`.
 

--- a/docs/ai/roles/cybersecurity_reviewer.md
+++ b/docs/ai/roles/cybersecurity_reviewer.md
@@ -18,10 +18,16 @@ names a `Selected Candidate`, review only that PR.
   data ingress, and generated artifacts.
 - Verify no secrets, real patient data, credentials, private keys, certificates,
   or tokens were added.
+- Verify the PR does not introduce untracked third-party, commercial,
+  open-source, or off-the-shelf software without an SBOM/update-plan note.
 - For auth or password changes, inspect `src/gui_auth.c`, `src/gui_users.c`,
   `src/pw_hash.c`, and matching headers.
 - For dependency or workflow changes, check whether the PR explains the remote
   CI and CodeQL evidence required.
+- For networked, installer, update, dependency, or AI/ML changes, require a
+  threat-model note covering attack surface, data flow, trust boundaries,
+  vulnerability monitoring, coordinated disclosure/patch expectations, and
+  privacy impact.
 - If there is no new attack surface, say that explicitly in the review comment.
 
 ## Output

--- a/docs/ai/roles/quality_reviewer.md
+++ b/docs/ai/roles/quality_reviewer.md
@@ -18,8 +18,13 @@ names a `Selected Candidate`, review only that PR.
 - Verify implementation evidence matches the spec and PR validation claims.
 - Confirm requirements and traceability files changed when behavior or evidence
   changed.
+- Confirm user requirements, acceptance criteria, objective pass/fail evidence,
+  and validation summary are present for the changed scope.
 - Confirm skipped checks are explicitly justified.
 - Confirm no controlled/generated documentation was edited casually.
+- Confirm risk controls named by the risk note/spec have verification evidence.
+- For AI/ML changes, confirm model/data governance, transparency, bias,
+  monitoring, and PCCP evidence are present before allowing the PR to proceed.
 - Treat this repo as a medical-software training project; do not require
   external QMS documents that are not present, but call out missing evidence if
   the PR itself depends on it.

--- a/docs/ai/roles/regulatory_reviewer.md
+++ b/docs/ai/roles/regulatory_reviewer.md
@@ -25,13 +25,19 @@ Packet names a `Selected Candidate`, review only that PR.
   workflow is introduced without human-approved acceptance criteria.
 - Confirm release-sensitive changes explain required CI, DVT, version, and
   artifact evidence.
+- Classify whether the PR adds, changes, removes, or depends on an AI-enabled
+  device software function. If yes, confirm there is enough information for AI
+  Safety Review: intended use, model/data provenance, transparency, bias,
+  performance monitoring, and PCCP/change-control impact.
+- Confirm whether the change could require a new submission, special 510(k),
+  PCCP update, labeling/user-information change, or human regulatory decision.
 
 ## Output
 
 This is an intermediate gate. Do not add `agent-approved`.
 
 - Pass: comment `Regulatory review outcome: PASSED`, remove
-  `ready-for-regulatory-review`, add `ready-for-traceability`, and verify
+  `ready-for-regulatory-review`, add `ready-for-ai-safety-review`, and verify
   labels.
 - Fail: comment `Regulatory review outcome: ISSUES FOUND`, remove
   `ready-for-regulatory-review`, add `regulatory-issues`, move the linked issue

--- a/docs/ai/roles/release.md
+++ b/docs/ai/roles/release.md
@@ -13,6 +13,8 @@ release issue. In smoke-test mode:
 - Check for release blockers.
 - Summarize current CI and open PR status.
 - Summarize whether the medical review chain is empty, blocked, or waiting.
+- Summarize whether any AI/ML evidence, PCCP decision, cybersecurity evidence,
+  SBOM/update-plan note, or human sign-off is missing.
 - Do not tag.
 - Do not publish a GitHub Release.
 - Do not modify release artifacts.
@@ -27,6 +29,13 @@ Before any tag or release:
 - DVT evidence is available or manual DVT sign-off is recorded.
 - Requirements traceability is consistent.
 - Version numbers, installer metadata, README, and release notes match.
+- Release evidence bundle is complete: intended use, requirements, architecture,
+  risk notes, specs, review comments, V&V evidence, traceability matrix,
+  cybersecurity/SBOM notes, AI/ML appendix when applicable, and known residual
+  risks or skipped checks.
+- Any AI/ML change has explicit AI Safety Review pass, model/data version
+  evidence, transparency/user information, bias/subgroup analysis or rationale,
+  performance-monitoring plan, and PCCP/change-control decision.
 - No open blocker, safety, or security issue is in scope.
 
 ## Release Commands

--- a/docs/ai/roles/reviewer.md
+++ b/docs/ai/roles/reviewer.md
@@ -53,7 +53,8 @@ Approve only if:
 
 Never merge. In the full medical pilot this role is superseded by
 `code_reviewer`, `quality_reviewer`, `cybersecurity_reviewer`,
-`regulatory_reviewer`, `traceability_tracker`, and `merger`.
+`regulatory_reviewer`, `ai_safety_reviewer`, `traceability_tracker`, and
+`merger`.
 
 ## Writeback Rules
 

--- a/docs/ai/roles/risk_analyst.md
+++ b/docs/ai/roles/risk_analyst.md
@@ -3,8 +3,9 @@
 ## Mission
 
 Assess one proposed change for medical-safety and process risk before design.
-This is a lightweight pilot role, not a substitute for a formal ISO 14971 risk
-management file.
+This role creates pilot risk evidence in the style of an ISO 14971 risk
+management entry. It is not a regulatory sign-off, but every note must be
+structured enough for an independent reviewer to audit the risk rationale.
 
 ## Trigger
 
@@ -40,11 +41,15 @@ Use this structure:
 - medical-safety impact
 - security and privacy impact
 - affected requirements or "none"
+- intended use, user population, operating environment, and foreseeable misuse
+- severity, probability, initial risk, risk controls, verification method,
+  residual risk, and residual-risk acceptability rationale
 - hazards and failure modes
 - existing controls
 - required design controls
 - validation expectations
 - residual risk for this pilot
+- human owner decision needed, if any
 
 For product-research feature candidates, also include:
 
@@ -53,6 +58,17 @@ For product-research feature candidates, also include:
 - MVP boundary that avoids copying proprietary UX
 - clinical-safety boundary and claims that must not be made
 - whether the candidate is safe to send to Architect
+
+For any AI-enabled or algorithmic decision-support candidate, also include:
+
+- whether the change adds, changes, removes, or depends on an AI/ML model
+- model purpose, input data, output, intended user, and clinical decision impact
+- data provenance and whether training, tuning, validation, or monitoring data
+  would be needed
+- bias, subgroup, transparency, human-in-the-loop, and performance-monitoring
+  risks that must be handled before design
+- whether a predetermined change control plan (PCCP) or human regulatory
+  decision is needed before implementation
 
 Commit only the risk note on `feature/<issue>-<slug>`, push it, then move the
 issue from `needs-risk` to `ready-for-design` and comment with the risk note
@@ -63,6 +79,9 @@ path.
 - If the issue proposes clinical thresholds, diagnosis, treatment advice, or
   real patient-care workflow changes without explicit human acceptance criteria,
   label `blocked` and explain the missing human decision.
+- If the issue adds or changes AI/ML behavior without enough information to
+  define intended use, data provenance, validation, transparency, bias,
+  monitoring, and change-control boundaries, label `blocked`.
 - If the issue cites competitor claims but lacks enough public source evidence
   to define a non-copying MVP, label `blocked` and request better source
   evidence or a narrower product hypothesis.

--- a/docs/ai/roles/tester.md
+++ b/docs/ai/roles/tester.md
@@ -16,6 +16,10 @@ issue.
 3. Map changed files to the validation matrix below.
 4. Run every applicable command available on the host.
 5. Record exact commands, pass/fail, skipped commands, and reason for skips.
+6. For any AI/ML or algorithmic decision-support change, verify the PR includes
+   model/data version evidence, intended-use limits, bias/subgroup checks,
+   transparency/user information, and performance-monitoring evidence or an
+   explicit not-applicable rationale.
 
 ## Validation Matrix
 
@@ -27,6 +31,7 @@ issue.
 | DVT report | `python dvt/run_dvt.py --no-build --build-dir build` after a successful build |
 | Coverage-sensitive changes | `run_coverage.bat` when GCC coverage and `gcovr` are available |
 | CI/workflow changes | Validate YAML syntax and explain which GitHub-only gates must run remotely |
+| AI/ML or algorithmic decision-support changes | Verify fixed model/version, data provenance, validation dataset or rationale, subgroup/bias checks, transparency text, human-in-the-loop limits, and monitoring/PCCP evidence |
 
 ## PR Body Template
 
@@ -40,6 +45,7 @@ When all applicable checks pass, open the PR with:
 - Commands run
 - Skipped checks and why
 - Medical-safety/security notes
+- AI/ML impact and evidence, or explicit "none"
 
 ## Failure Handling
 

--- a/docs/ai/roles/traceability_tracker.md
+++ b/docs/ai/roles/traceability_tracker.md
@@ -24,6 +24,8 @@ Verify the change links across:
 - changed source/header files
 - changed tests and DVT evidence
 - validation evidence in the PR body and CI
+- Quality, Cybersecurity, Regulatory, and AI Safety review comments
+- AI/ML evidence links or an explicit not-applicable rationale
 
 Use targeted `git grep` or `Select-String` checks for new or modified IDs.
 


### PR DESCRIPTION
## Summary
- Adds an AI Safety Reviewer gate between regulatory review and traceability review.
- Enables AI safety labels and retry handling for missing AI/ML evidence.
- Strengthens medical-role guidance for risk, architecture, testing, quality, cybersecurity, regulatory review, traceability, and release evidence.
- Updates the Medvital Agentry pilot flow docs so the enabled workflow matches the role chain.

## Validation
- `git diff --check`
- YAML parse for `agentry/config.yml`
- `agentry.exe doctor --target . --init-labels`
- `agentry.exe status --target .`