### PR TITLE
Feature: make the clinician idle timeout configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(monitor_lib STATIC
     src/patient.c
     src/pw_hash.c
     src/app_config.c
+    src/session_timeout.c
     src/news2.c
     src/alarm_limits.c
     src/trend.c

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Patient Vital Signs Monitor
+﻿# Patient Vital Signs Monitor
 
-[![CI — Build & Test](https://github.com/vinu-dev/medvital-monitor/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/vinu-dev/medvital-monitor/actions/workflows/ci.yml)
+[![CI â€” Build & Test](https://github.com/vinu-dev/medvital-monitor/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/vinu-dev/medvital-monitor/actions/workflows/ci.yml)
 
 Medical device software for real-time patient vital sign monitoring and alert generation.
 Built to **IEC 62304 Class B** and **FDA SW Validation Guidance** standards.
-**Version 2.7.0** — Six vital signs (including respiration rate), NEWS2 early warning score, configurable alarm limits (IEC 60601-1-8), trend sparkline graphs, a session alarm event review log, role-based settings access, rolling status message in simulation mode, 293 unit + 14 integration tests (307 total).
+**Version 2.8.0** — Six vital signs (including respiration rate), NEWS2 early warning score, configurable alarm limits (IEC 60601-1-8), trend sparkline graphs, a session alarm event review log, configurable clinician idle-session locking, role-based settings access, rolling status message in simulation mode, 307 unit + 14 integration tests (321 total).
 
 ---
 
@@ -40,15 +40,15 @@ sparkline graphs.  A console demonstration executable is also included.
 | Heart rate         | bpm     | AHA/ACC 2019                          |
 | Systolic BP        | mmHg    | JNC-8 / ESC 2018                      |
 | Diastolic BP       | mmHg    | JNC-8 / ESC 2018                      |
-| Body temperature   | °C      | WHO Clinical References               |
+| Body temperature   | Â°C      | WHO Clinical References               |
 | SpO2               | %       | British Thoracic Society              |
 | Respiration rate   | br/min  | IEC 80601-2-49 / NEWS2 (RCP 2017)     |
-| BMI (derived)      | kg/m²   | WHO BMI categories                    |
-| NEWS2 score        | 0–20    | Royal College of Physicians 2017      |
+| BMI (derived)      | kg/mÂ²   | WHO BMI categories                    |
+| NEWS2 score        | 0â€“20    | Royal College of Physicians 2017      |
 
 **Design constraints (IEC 62304 Class B):**
 
-- No heap allocation — all storage is stack or statically sized.
+- No heap allocation â€” all storage is stack or statically sized.
 - Patient record holds up to `MAX_READINGS` (10) readings per monitoring cycle;
   the GUI resets and continues automatically when the buffer is full.
 - Hardware acquisition isolated behind a HAL (`hw_vitals.h`) so the simulation
@@ -123,35 +123,35 @@ No heap allocation is used anywhere in production code.
 
 | Structure       | Storage                                       |
 |-----------------|-----------------------------------------------|
-| `VitalSigns`    | 6 fields — ~24 bytes                          |
-| `Alert`         | level + message strings — ~132 bytes          |
-| `PatientRecord` | PatientInfo + 10 × VitalSigns + int           |
+| `VitalSigns`    | 6 fields â€” ~24 bytes                          |
+| `Alert`         | level + message strings â€” ~132 bytes          |
+| `PatientRecord` | PatientInfo + 10 Ã— VitalSigns + int           |
 | Simulation      | 20-entry static table in `sim_vitals.c`       |
 
 ---
 
 ## Modules
 
-### `vitals.c` / `vitals.h` — UNIT-VIT
+### `vitals.c` / `vitals.h` â€” UNIT-VIT
 
 Core classification engine.  Validates each vital sign parameter against
 AHA/ACC-derived clinical thresholds and returns an `AlertLevel`.
 
 | Function                 | Description                                           |
 |--------------------------|-------------------------------------------------------|
-| `check_heart_rate()`     | Classifies bpm → NORMAL / WARNING / CRITICAL          |
+| `check_heart_rate()`     | Classifies bpm â†’ NORMAL / WARNING / CRITICAL          |
 | `check_blood_pressure()` | Classifies systolic + diastolic together              |
-| `check_temperature()`    | Classifies °C → NORMAL / WARNING / CRITICAL           |
-| `check_spo2()`           | Classifies SpO2 % → NORMAL / WARNING / CRITICAL       |
-| `check_respiration_rate()`| Classifies br/min → NORMAL / WARNING / CRITICAL      |
+| `check_temperature()`    | Classifies Â°C â†’ NORMAL / WARNING / CRITICAL           |
+| `check_spo2()`           | Classifies SpO2 % â†’ NORMAL / WARNING / CRITICAL       |
+| `check_respiration_rate()`| Classifies br/min â†’ NORMAL / WARNING / CRITICAL      |
 | `overall_alert_level()`  | Returns the highest level across all six parameters   |
-| `calculate_bmi()`        | BMI = weight / height²; returns -1.0 for invalid input|
-| `bmi_category()`         | Maps BMI float → WHO category string                  |
-| `alert_level_str()`      | Maps `AlertLevel` → "NORMAL" / "WARNING" / "CRITICAL" |
+| `calculate_bmi()`        | BMI = weight / heightÂ²; returns -1.0 for invalid input|
+| `bmi_category()`         | Maps BMI float â†’ WHO category string                  |
+| `alert_level_str()`      | Maps `AlertLevel` â†’ "NORMAL" / "WARNING" / "CRITICAL" |
 
 ---
 
-### `alerts.c` / `alerts.h` — UNIT-ALT
+### `alerts.c` / `alerts.h` â€” UNIT-ALT
 
 Translates a `VitalSigns` snapshot into a list of human-readable `Alert`
 records, one per out-of-range parameter.
@@ -162,7 +162,7 @@ records, one per out-of-range parameter.
 
 ---
 
-### `patient.c` / `patient.h` — UNIT-PAT
+### `patient.c` / `patient.h` â€” UNIT-PAT
 
 Top-level patient record management.  Stores demographics and a history of
 up to `MAX_READINGS` (10) vital sign readings.
@@ -178,7 +178,7 @@ up to `MAX_READINGS` (10) vital sign readings.
 
 ---
 
-### `gui_auth.c` / `gui_auth.h` — UNIT-GUI (auth)
+### `gui_auth.c` / `gui_auth.h` â€” UNIT-GUI (auth)
 
 Fixed-credential authentication for the desktop GUI.
 
@@ -191,7 +191,7 @@ Default credential: **admin / Monitor@2026**
 
 ---
 
-### `hw_vitals.h` — UNIT-HAL
+### `hw_vitals.h` â€” UNIT-HAL
 
 Hardware Abstraction Layer interface.  The GUI calls only these two functions;
 replacing `sim_vitals.c` with a hardware driver is the only change needed to
@@ -204,33 +204,33 @@ connect real sensors.
 
 ---
 
-### `sim_vitals.c` — UNIT-SIM
+### `sim_vitals.c` â€” UNIT-SIM
 
 Simulation back-end for the HAL.  Cycles through a 20-entry clinical scenario
 table covering four phases:
 
 | Phase         | Indices | Status   | Description                          |
 |---------------|---------|----------|--------------------------------------|
-| Stable        | 0–4     | NORMAL   | All parameters within clinical range |
-| Deteriorating | 5–8     | WARNING  | Gradual rise towards threshold       |
-| Critical      | 9–11    | CRITICAL | Life-threatening values              |
-| Recovering    | 12–19   | WARNING→NORMAL | Progressive return to stable  |
+| Stable        | 0â€“4     | NORMAL   | All parameters within clinical range |
+| Deteriorating | 5â€“8     | WARNING  | Gradual rise towards threshold       |
+| Critical      | 9â€“11    | CRITICAL | Life-threatening values              |
+| Recovering    | 12â€“19   | WARNINGâ†’NORMAL | Progressive return to stable  |
 
 ---
 
-### `news2.c` / `news2.h` — UNIT-NEW
+### `news2.c` / `news2.h` â€” UNIT-NEW
 
 NEWS2 Early Warning Score per Royal College of Physicians 2017.
 
 | Function            | Description                                                  |
 |---------------------|--------------------------------------------------------------|
-| `news2_calculate()` | Computes aggregate NEWS2 score (0–20) from 5 vitals + AVPU   |
+| `news2_calculate()` | Computes aggregate NEWS2 score (0â€“20) from 5 vitals + AVPU   |
 
-Risk classifications: LOW (0–4), LOW_MEDIUM (any single param = 3), MEDIUM (5–6), HIGH (≥ 7).
+Risk classifications: LOW (0â€“4), LOW_MEDIUM (any single param = 3), MEDIUM (5â€“6), HIGH (â‰¥ 7).
 
 ---
 
-### `alarm_limits.c` / `alarm_limits.h` — UNIT-ALM
+### `alarm_limits.c` / `alarm_limits.h` â€” UNIT-ALM
 
 Configurable per-patient alarm limits per IEC 60601-1-8.
 
@@ -243,7 +243,7 @@ Configurable per-patient alarm limits per IEC 60601-1-8.
 
 ---
 
-### `trend.c` / `trend.h` — UNIT-TRD
+### `trend.c` / `trend.h` â€” UNIT-TRD
 
 Trend direction detection and sparkline data extraction.
 
@@ -258,12 +258,12 @@ Trend direction detection and sparkline data extraction.
 
 | Parameter    | NORMAL           | WARNING                          | CRITICAL              |
 |--------------|------------------|----------------------------------|-----------------------|
-| Heart Rate   | 60–100 bpm       | 41–59 bpm / 101–150 bpm          | ≤ 40 / ≥ 151 bpm      |
-| Systolic BP  | 90–140 mmHg      | 71–89 mmHg / 141–180 mmHg        | ≤ 70 / ≥ 181 mmHg     |
-| Diastolic BP | 60–90 mmHg       | 41–59 mmHg / 91–120 mmHg         | ≤ 40 / ≥ 121 mmHg     |
-| Temperature  | 36.1–37.2 °C     | 35.0–36.0 °C / 37.3–39.5 °C     | < 35.0 / > 39.5 °C   |
-| SpO2         | 95–100 %         | 90–94 %                          | < 90 %                |
-| Resp Rate    | 12–20 br/min     | 9–11 / 21–24 br/min             | ≤ 8 / ≥ 25 br/min     |
+| Heart Rate   | 60â€“100 bpm       | 41â€“59 bpm / 101â€“150 bpm          | â‰¤ 40 / â‰¥ 151 bpm      |
+| Systolic BP  | 90â€“140 mmHg      | 71â€“89 mmHg / 141â€“180 mmHg        | â‰¤ 70 / â‰¥ 181 mmHg     |
+| Diastolic BP | 60â€“90 mmHg       | 41â€“59 mmHg / 91â€“120 mmHg         | â‰¤ 40 / â‰¥ 121 mmHg     |
+| Temperature  | 36.1â€“37.2 Â°C     | 35.0â€“36.0 Â°C / 37.3â€“39.5 Â°C     | < 35.0 / > 39.5 Â°C   |
+| SpO2         | 95â€“100 %         | 90â€“94 %                          | < 90 %                |
+| Resp Rate    | 12â€“20 br/min     | 9â€“11 / 21â€“24 br/min             | â‰¤ 8 / â‰¥ 25 br/min     |
 
 *Sources: AHA/ACC 2019, JNC-8, ESC 2018, WHO, British Thoracic Society, IEC 80601-2-49*
 
@@ -273,13 +273,13 @@ Trend direction detection and sparkline data extraction.
 
 ### End-user install (no development tools needed)
 
-Download **`PatientMonitorSetup-2.7.0.exe`** from the
+Download **`PatientMonitorSetup-2.8.0.exe`** from the
 [Releases](https://github.com/vinu-dev/medvital-monitor/releases) page and
 double-click to run the setup wizard.
 
 If you want the standalone executable instead, download
-**`PatientMonitor-v2.7.0.exe`**. The portable bundle is
-**`PatientMonitor-v2.7.0-portable.zip`**.
+**`PatientMonitor-v2.8.0.exe`**. The portable bundle is
+**`PatientMonitor-v2.8.0-portable.zip`**.
 
 | Step | What happens |
 |------|-------------|
@@ -287,11 +287,11 @@ If you want the standalone executable instead, download
 | 2. Select shortcuts | Start Menu group created automatically; optional desktop shortcut |
 | 3. Finish | App launches immediately after install |
 
-**Uninstall:** Settings → Apps → Patient Vital Signs Monitor → Uninstall
-*(or Control Panel → Programs → Uninstall a program)*
+**Uninstall:** Settings â†’ Apps â†’ Patient Vital Signs Monitor â†’ Uninstall
+*(or Control Panel â†’ Programs â†’ Uninstall a program)*
 
 **System requirements:** Windows 10 or later (32-bit or 64-bit). No additional
-runtimes or redistributables required — the executable depends only on standard
+runtimes or redistributables required â€” the executable depends only on standard
 Windows system DLLs (`GDI32`, `KERNEL32`, `USER32`).
 
 ### Build your own installer (developers)
@@ -300,7 +300,7 @@ Windows system DLLs (`GDI32`, `KERNEL32`, `USER32`).
 :: One-time: install Inno Setup 6
 winget install --id JRSoftware.InnoSetup
 
-:: Build app + compile installer  ->  dist\PatientMonitorSetup-2.7.0.exe
+:: Build app + compile installer  ->  dist\PatientMonitorSetup-2.8.0.exe
 create_installer.bat
 ```
 
@@ -313,7 +313,7 @@ create_installer.bat
 | Tool    | Minimum   | Install                                                      |
 |---------|-----------|--------------------------------------------------------------|
 | CMake   | 3.15      | `winget install Kitware.CMake`                               |
-| MinGW GCC | 6.3+   | https://sourceforge.net/projects/mingw/ — select gcc-g++, mingw32-make |
+| MinGW GCC | 6.3+   | https://sourceforge.net/projects/mingw/ â€” select gcc-g++, mingw32-make |
 | Git     | Any       | `winget install Git.Git`  (needed by CMake FetchContent)     |
 
 > **Note:** MSVC is **not** required.  The project uses MinGW GCC exclusively.
@@ -321,13 +321,13 @@ create_installer.bat
 
 ### Scripts
 
-Five scripts cover the full workflow — double-click in File Explorer or run
+Five scripts cover the full workflow â€” double-click in File Explorer or run
 from a terminal.
 
 | Script                 | What it does                                                          |
 |------------------------|-----------------------------------------------------------------------|
 | `build.bat`            | Configure + build everything (first run or incremental). Launches GUI.|
-| `run_tests.bat`        | Rebuild test targets and run all 307 tests. Exits non-zero on failure.|
+| `run_tests.bat`        | Rebuild test targets and run all 321 tests. Exits non-zero on failure.|
 | `run_coverage.bat`     | Build with `--coverage`, run tests, generate HTML + XML reports.      |
 | `generate_docs.bat`    | Run Doxygen to produce HTML + XML design documentation.               |
 | `create_installer.bat` | Build release exe + compile Windows installer (`dist\` folder).       |
@@ -391,7 +391,7 @@ build\patient_monitor_gui.exe
 1. Write `src/hw_driver.c` implementing `hw_init()` and `hw_get_next_reading()`
    (see `include/hw_vitals.h` for the interface contract).
 2. Replace `src/sim_vitals.c` with `src/hw_driver.c` in `CMakeLists.txt`.
-3. Rebuild — no other source file changes are needed.
+3. Rebuild â€” no other source file changes are needed.
 
 ---
 
@@ -419,8 +419,8 @@ persisted in `users.dat` in the same directory as the executable.
 | Settings panel             | Yes   | Yes      |
 | Simulation toggle          | Yes   | Yes      |
 | Alarm limits config        | Yes   | Yes      |
-| Add / Remove users         | Yes   | —        |
-| Set any user's password    | Yes   | —        |
+| Add / Remove users         | Yes   | â€”        |
+| Set any user's password    | Yes   | â€”        |
 
 The header bar shows a **gold ADMIN** or **teal CLINICAL** pill badge next to
 the logged-in user's name.
@@ -432,21 +432,26 @@ Tabs visible depend on role.
 
 **Users tab** (Admin only)
 - Lists all accounts with username, display name, and role.
-- **Add User** — create a new account with username, display name, initial
+- **Add User** â€” create a new account with username, display name, initial
   password (min 8 chars), and role selection.
-- **Remove** — delete a selected account.  The last admin account and the
+- **Remove** â€” delete a selected account.  The last admin account and the
   currently logged-in user cannot be removed.
-- **Set Password** — override any user's password without requiring the
+- **Set Password** â€” override any user's password without requiring the
   current password.
 
-**Simulation tab** — toggle simulation mode on/off, persisted to `monitor.cfg`.
+**Simulation tab** â€” toggle simulation mode on/off, persisted to `monitor.cfg`.
 
-**Alarm Limits tab** — per-patient alarm thresholds per IEC 60601-1-8.
+**Session tab** (Admin only) â€” configure the clinician idle timeout in the
+approved range `1..30` minutes. The value is persisted to `monitor.cfg`,
+applied immediately, and idle expiry locks the dashboard until the same user
+re-authenticates.
+
+**Alarm Limits tab** â€” per-patient alarm thresholds per IEC 60601-1-8.
 Edit limits for HR, SBP, DBP, Temp, SpO2, RR. Apply & Save or Reset Defaults.
 
-**My Account tab** — change own password (current + new + confirm).
+**My Account tab** â€” change own password (current + new + confirm).
 
-**About tab** — application version, standard (IEC 62304 Class B), and
+**About tab** â€” application version, standard (IEC 62304 Class B), and
 requirements revision.
 
 ---
@@ -459,28 +464,29 @@ requirements revision.
 
 | File                                            | Tests  | Requirements                      |
 |-------------------------------------------------|--------|-----------------------------------|
-| `tests/unit/test_vitals.cpp`                    | 80     | SWR-VIT-001 – 008                 |
-| `tests/unit/test_alerts.cpp`                    | 11     | SWR-ALT-001 – 004                 |
-| `tests/unit/test_patient.cpp`                   | 29     | SWR-PAT-001 – 008                 |
-| `tests/unit/test_auth.cpp`                      | 41     | SWR-GUI-001–002, SWR-SEC-001–004  |
+| `tests/unit/test_vitals.cpp`                    | 80     | SWR-VIT-001 â€“ 008                 |
+| `tests/unit/test_alerts.cpp`                    | 11     | SWR-ALT-001 â€“ 004                 |
+| `tests/unit/test_patient.cpp`                   | 29     | SWR-PAT-001 â€“ 008                 |
+| `tests/unit/test_auth.cpp`                      | 41     | SWR-GUI-001â€“002, SWR-SEC-001â€“004  |
 | `tests/unit/test_news2.cpp`                     | 53     | SWR-NEW-001                       |
 | `tests/unit/test_alarm_limits.cpp`              | 31     | SWR-ALM-001                       |
 | `tests/unit/test_trend.cpp`                     | 18     | SWR-TRD-001                       |
 | `tests/unit/test_hal.cpp`                       | 12     | Supporting HAL / simulator checks only |
-| `tests/unit/test_config.cpp`                    | 10     | Supporting config persistence checks only |
+| `tests/unit/test_config.cpp`                    | 17     | SWR-GUI-014 + supporting config persistence evidence for SWR-GUI-010 |
+| `tests/unit/test_session_timeout.cpp`           | 7      | SWR-SEC-005                       |
 | `tests/unit/test_localization.cpp`              | 8      | SWR-GUI-012                       |
 | `tests/integration/test_patient_monitoring.cpp` | 7      | SWR-PAT-*, SWR-VIT-*, SWR-ALT-*   |
 | `tests/integration/test_alert_escalation.cpp`   | 7      | SWR-VIT-*, SWR-ALT-*, SWR-PAT-007 |
-| **Total**                                       | **307** | **40 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
+| **Total**                                       | **321** | **42 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
 
 ### Test techniques applied
 
 | Technique                   | Applied to                                      |
 |-----------------------------|-------------------------------------------------|
 | Equivalence Partitioning    | All six vital sign classification functions     |
-| Boundary Value Analysis     | Every threshold boundary (±1 from each limit)  |
+| Boundary Value Analysis     | Every threshold boundary (Â±1 from each limit)  |
 | Boundary Sweep Tables       | Heart rate and SpO2 full boundary sweep         |
-| Escalation / Deescalation   | NORMAL → WARNING → CRITICAL and back            |
+| Escalation / Deescalation   | NORMAL â†’ WARNING â†’ CRITICAL and back            |
 | Multi-parameter crisis      | All six parameters critical simultaneously      |
 | Capacity enforcement        | `patient_add_reading()` beyond MAX_READINGS     |
 | Independence verification   | Two patients with different statuses            |
@@ -509,7 +515,7 @@ ctest --test-dir build --output-on-failure
 ### Setup
 
 ```bat
-pip install gcovr      :: once — for HTML + Cobertura XML output
+pip install gcovr      :: once â€” for HTML + Cobertura XML output
 run_coverage.bat
 ```
 
@@ -532,7 +538,7 @@ run_coverage.bat
 |---------------|---------|---------------------------------------------|
 | Statement     | 100%    | 100%                                        |
 | Branch        | 100%    | 100%                                        |
-| MC/DC         | N/A     | 100% — requires VectorCAST / BullseyeCoverage |
+| MC/DC         | N/A     | 100% â€” requires VectorCAST / BullseyeCoverage |
 
 ---
 
@@ -566,7 +572,7 @@ Opens `docs\html\index.html` automatically.
 | Call graphs              | Per-function call and caller diagrams (SVG)                       |
 | Include dependency graph | Module dependency visualisation                                   |
 | Source browser           | Annotated source with cross-references                            |
-| Warnings log             | `docs\doxygen_warnings.log` — undocumented items                  |
+| Warnings log             | `docs\doxygen_warnings.log` â€” undocumented items                  |
 
 ---
 
@@ -588,18 +594,19 @@ Opens `docs\html\index.html` automatically.
 
 | Requirement ID  | Module                    | Test File                        |
 |-----------------|---------------------------|----------------------------------|
-| SWR-VIT-001–008 | `vitals.c`                | `test_vitals.cpp`                |
+| SWR-VIT-001â€“008 | `vitals.c`                | `test_vitals.cpp`                |
 | SWR-NEW-001     | `news2.c`                 | `test_news2.cpp`                 |
 | SWR-ALM-001     | `alarm_limits.c`          | `test_alarm_limits.cpp`          |
 | SWR-TRD-001     | `trend.c`                 | `test_trend.cpp`                 |
-| SWR-ALT-001–004 | `alerts.c`                | `test_alerts.cpp`                |
-| SWR-PAT-001–006 | `patient.c`               | `test_patient.cpp`               |
-| SWR-GUI-001–002 | `gui_auth.c`              | `test_auth.cpp`                  |
-| SWR-GUI-003–004 | `gui_main.c`              | GUI demonstration                |
-| SWR-GUI-005–006 | `hw_vitals.h`/`sim_vitals.c` | `test_hal.cpp` + GUI demo     |
-| SWR-SEC-001–004 | `gui_users.c`, `pw_hash.c`| `test_auth.cpp`                  |
-| SWR-GUI-007     | `gui_users.c`/`gui_main.c`| `test_auth.cpp` — UserManagement |
-| SWR-GUI-008-010 | `gui_main.c`, `app_config.c`| `test_config.cpp` + visual    |
+| SWR-ALT-001â€“004 | `alerts.c`                | `test_alerts.cpp`                |
+| SWR-PAT-001â€“006 | `patient.c`               | `test_patient.cpp`               |
+| SWR-GUI-001â€“002 | `gui_auth.c`              | `test_auth.cpp`                  |
+| SWR-GUI-003â€“004 | `gui_main.c`              | GUI demonstration                |
+| SWR-GUI-005â€“006 | `hw_vitals.h`/`sim_vitals.c` | `test_hal.cpp` + GUI demo     |
+| SWR-SEC-001â€“004 | `gui_users.c`, `pw_hash.c`| `test_auth.cpp`                  |
+| SWR-SEC-005     | `session_timeout.c`, `gui_main.c` | `test_session_timeout.cpp` + GUI review |
+| SWR-GUI-007     | `gui_users.c`/`gui_main.c`| `test_auth.cpp` â€” UserManagement |
+| SWR-GUI-008-010, SWR-GUI-014 | `gui_main.c`, `app_config.c`| `test_config.cpp` + visual    |
 | SWR-GUI-011     | `gui_main.c`              | GUI demonstration                |
 | SWR-INT-MON     | All modules               | `test_patient_monitoring.cpp`    |
 | SWR-INT-ESC     | All modules               | `test_alert_escalation.cpp`      |
@@ -612,76 +619,79 @@ Full traceability matrix: `requirements/TRACEABILITY.md`
 
 ```
 medvital-monitor/
-├── CMakeLists.txt                   # Root build configuration
-├── Doxyfile                         # Doxygen documentation configuration
-├── README.md                        # This file
-│
-├── include/
-│   ├── vitals.h                     # Vital signs types and validation API
-│   ├── alerts.h                     # Alert record structure and generation API
-│   ├── patient.h                    # Patient record management API
-│   ├── gui_auth.h                   # GUI authentication API
-│   ├── gui_users.h                  # Multi-user account management API
-│   ├── hw_vitals.h                  # Hardware Abstraction Layer interface
-│   ├── news2.h                      # NEWS2 Early Warning Score API
-│   ├── alarm_limits.h               # Configurable alarm limits API
-│   ├── trend.h                      # Trend direction + sparkline API
-│   └── app_config.h                 # Application configuration persistence
-│
-├── src/
-│   ├── vitals.c                     # Vital sign validation + BMI  (UNIT-VIT)
-│   ├── alerts.c                     # Alert record generation      (UNIT-ALT)
-│   ├── patient.c                    # Patient record management     (UNIT-PAT)
-│   ├── gui_auth.c                   # Auth delegation layer         (UNIT-GUI)
-│   ├── gui_users.c                  # Multi-user account management (UNIT-USR)
-│   ├── pw_hash.c                    # SHA-256 password hashing      (UNIT-SEC)
-│   ├── sim_vitals.c                 # Simulation HAL back-end       (UNIT-SIM)
-│   ├── news2.c                      # NEWS2 scoring engine          (UNIT-NEW)
-│   ├── alarm_limits.c               # Alarm limit config + check    (UNIT-ALM)
-│   ├── trend.c                      # Trend analysis + extraction   (UNIT-TRD)
-│   ├── app_config.c                 # Config persistence            (UNIT-CFG)
-│   ├── gui_main.c                   # Win32 GUI (5 windows)         (UNIT-GUI)
-│   └── main.c                       # Console entry point
-│
-├── tests/
-│   ├── CMakeLists.txt
-│   ├── unit/
-│   │   ├── test_vitals.cpp          # 80 tests — SWR-VIT-001–008
-│   │   ├── test_alerts.cpp          # 11 tests — SWR-ALT
-│   │   ├── test_patient.cpp         # 29 tests — SWR-PAT
-│   │   ├── test_auth.cpp            # 41 tests — SWR-GUI/SEC
-│   │   ├── test_news2.cpp           # 53 tests — SWR-NEW-001
-│   │   ├── test_alarm_limits.cpp    # 31 tests — SWR-ALM-001
-│   │   ├── test_trend.cpp           # 18 tests — SWR-TRD-001
-│   │   ├── test_hal.cpp             # 12 tests — SWR-GUI-005/006
-│   │   ├── test_config.cpp          # 10 tests — SWR-GUI-010
-│   │   └── test_localization.cpp    # 8 tests — SWR-GUI-012
-│   └── integration/
-│       ├── test_patient_monitoring.cpp  # 7 tests — SWR-PAT-*, SWR-VIT-*, SWR-ALT-*
-│       └── test_alert_escalation.cpp    # 7 tests — SWR-VIT-*, SWR-ALT-*, SWR-PAT-007
-│
-├── requirements/
+â”œâ”€â”€ CMakeLists.txt                   # Root build configuration
+â”œâ”€â”€ Doxyfile                         # Doxygen documentation configuration
+â”œâ”€â”€ README.md                        # This file
+â”‚
+â”œâ”€â”€ include/
+â”‚   â”œâ”€â”€ vitals.h                     # Vital signs types and validation API
+â”‚   â”œâ”€â”€ alerts.h                     # Alert record structure and generation API
+â”‚   â”œâ”€â”€ patient.h                    # Patient record management API
+â”‚   â”œâ”€â”€ gui_auth.h                   # GUI authentication API
+â”‚   â”œâ”€â”€ gui_users.h                  # Multi-user account management API
+â”‚   â”œâ”€â”€ hw_vitals.h                  # Hardware Abstraction Layer interface
+â”‚   â”œâ”€â”€ news2.h                      # NEWS2 Early Warning Score API
+â”‚   â”œâ”€â”€ alarm_limits.h               # Configurable alarm limits API
+â”‚   â”œâ”€â”€ trend.h                      # Trend direction + sparkline API
+â”‚   â”œâ”€â”€ app_config.h                 # Application configuration persistence
+â”‚   â””â”€â”€ session_timeout.h            # Idle session-timeout policy helpers
+â”‚
+â”œâ”€â”€ src/
+â”‚   â”œâ”€â”€ vitals.c                     # Vital sign validation + BMI  (UNIT-VIT)
+â”‚   â”œâ”€â”€ alerts.c                     # Alert record generation      (UNIT-ALT)
+â”‚   â”œâ”€â”€ patient.c                    # Patient record management     (UNIT-PAT)
+â”‚   â”œâ”€â”€ gui_auth.c                   # Auth delegation layer         (UNIT-GUI)
+â”‚   â”œâ”€â”€ gui_users.c                  # Multi-user account management (UNIT-USR)
+â”‚   â”œâ”€â”€ pw_hash.c                    # SHA-256 password hashing      (UNIT-SEC)
+â”‚   â”œâ”€â”€ sim_vitals.c                 # Simulation HAL back-end       (UNIT-SIM)
+â”‚   â”œâ”€â”€ news2.c                      # NEWS2 scoring engine          (UNIT-NEW)
+â”‚   â”œâ”€â”€ alarm_limits.c               # Alarm limit config + check    (UNIT-ALM)
+â”‚   â”œâ”€â”€ trend.c                      # Trend analysis + extraction   (UNIT-TRD)
+â”‚   â”œâ”€â”€ app_config.c                 # Config persistence            (UNIT-CFG)
+â”‚   â”œâ”€â”€ session_timeout.c            # Idle session-timeout policy  (UNIT-SEC)
+â”‚   â”œâ”€â”€ gui_main.c                   # Win32 GUI (5 windows)         (UNIT-GUI)
+â”‚   â””â”€â”€ main.c                       # Console entry point
+â”‚
+â”œâ”€â”€ tests/
+â”‚   â”œâ”€â”€ CMakeLists.txt
+â”‚   â”œâ”€â”€ unit/
+â”‚   â”‚   â”œâ”€â”€ test_vitals.cpp          # 80 tests â€” SWR-VIT-001â€“008
+â”‚   â”‚   â”œâ”€â”€ test_alerts.cpp          # 11 tests â€” SWR-ALT
+â”‚   â”‚   â”œâ”€â”€ test_patient.cpp         # 29 tests â€” SWR-PAT
+â”‚   â”‚   â”œâ”€â”€ test_auth.cpp            # 41 tests â€” SWR-GUI/SEC
+â”‚   â”‚   â”œâ”€â”€ test_news2.cpp           # 53 tests â€” SWR-NEW-001
+â”‚   â”‚   â”œâ”€â”€ test_alarm_limits.cpp    # 31 tests â€” SWR-ALM-001
+â”‚   â”‚   â”œâ”€â”€ test_trend.cpp           # 18 tests â€” SWR-TRD-001
+â”‚   â”‚   â”œâ”€â”€ test_hal.cpp             # 12 tests â€” SWR-GUI-005/006
+â”‚   â”‚   â”œâ”€â”€ test_config.cpp          # 17 tests â€” SWR-GUI-014 + SWR-GUI-010 support
+â”‚   â”‚   â””â”€â”€ test_session_timeout.cpp # 7 tests â€” SWR-SEC-005
+â”‚   â”‚   â””â”€â”€ test_localization.cpp    # 8 tests â€” SWR-GUI-012
+â”‚   â””â”€â”€ integration/
+â”‚       â”œâ”€â”€ test_patient_monitoring.cpp  # 7 tests â€” SWR-PAT-*, SWR-VIT-*, SWR-ALT-*
+â”‚       â””â”€â”€ test_alert_escalation.cpp    # 7 tests â€” SWR-VIT-*, SWR-ALT-*, SWR-PAT-007
+â”‚
+â”œâ”€â”€ requirements/
 |   |-- UNS.md                       # User Needs (17 items)
-|   |-- SYS.md                       # System Requirements (21 items)
-│   ├── SWR.md                       # Software Requirements (40 items)
-│   └── TRACEABILITY.md              # RTM — 17/17 UNS, 40/40 SWR, 307 tests
-│
-├── build.bat                        # Configure + build + launch GUI
-|-- run_tests.bat                    # Run all 307 tests
-├── run_coverage.bat                 # GCC coverage report (gcov + gcovr)
-├── generate_docs.bat                # Doxygen HTML + XML documentation
-├── create_installer.bat             # Build release + compile Windows installer
-├── installer.iss                    # Inno Setup 6 installer script
-├── make_icon.py                     # Regenerate resources/app.ico from source
-│
-├── resources/
-│   ├── app.ico                      # Medical cross icon (16/32/48 px)
-│   └── app.rc                       # Windows resource script (icon + version info)
-│
-├── dvt/
-│   ├── run_dvt.py                   # DVT automation script
-│   └── results/                     # DVT execution reports
-│
-└── dist/                            # Release artifacts (exe, zip, installer)
+|   |-- SYS.md                       # System Requirements (22 items)
+â”‚   â”œâ”€â”€ SWR.md                       # Software Requirements (42 items)
+â”‚   â””â”€â”€ TRACEABILITY.md              # RTM â€” 17/17 UNS, 42/42 SWR, 321 tests
+â”‚
+â”œâ”€â”€ build.bat                        # Configure + build + launch GUI
+|-- run_tests.bat                    # Run all 321 tests
+â”œâ”€â”€ run_coverage.bat                 # GCC coverage report (gcov + gcovr)
+â”œâ”€â”€ generate_docs.bat                # Doxygen HTML + XML documentation
+â”œâ”€â”€ create_installer.bat             # Build release + compile Windows installer
+â”œâ”€â”€ installer.iss                    # Inno Setup 6 installer script
+â”œâ”€â”€ make_icon.py                     # Regenerate resources/app.ico from source
+â”‚
+â”œâ”€â”€ resources/
+â”‚   â”œâ”€â”€ app.ico                      # Medical cross icon (16/32/48 px)
+â”‚   â””â”€â”€ app.rc                       # Windows resource script (icon + version info)
+â”‚
+â”œâ”€â”€ dvt/
+â”‚   â”œâ”€â”€ run_dvt.py                   # DVT automation script
+â”‚   â””â”€â”€ results/                     # DVT execution reports
+â”‚
+â””â”€â”€ dist/                            # Release artifacts (exe, zip, installer)
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
-# Architecture — Patient Vital Signs Monitor
+﻿# Architecture â€” Patient Vital Signs Monitor
 
 **Document ID:** ARCH-001-REV-A  
 **Version:** 2.1.0  
 **Date:** 2026-04-08  
-**Standard:** IEC 62304 §5.3 — Software architectural design  
+**Standard:** IEC 62304 Â§5.3 â€” Software architectural design  
 
 ---
 
@@ -12,31 +12,31 @@
 The Patient Vital Signs Monitor is designed as a **layered, API-first system**
 whose domain logic is intentionally decoupled from the presentation layer. This
 allows the same clinically-verified C library to power a Win32 desktop client
-today and a web or mobile application in the future — without touching the
+today and a web or mobile application in the future â€” without touching the
 certified core.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                       PRESENTATION LAYER                         │
-│   Win32 GUI (current)  │  Web SPA (future)  │  Mobile (future)  │
-└────────────────────────┬────────────────────────────────────────┘
-                         │ HTTP / JSON REST   (Win32 uses direct calls)
-┌────────────────────────▼────────────────────────────────────────┐
-│                       API GATEWAY LAYER  (future)                │
-│           REST Server — libmongoose (single-header C)            │
-│           Endpoints: /vitals  /alerts  /patient  /auth           │
-└────────────────────────┬────────────────────────────────────────┘
-                         │ C function calls
-┌────────────────────────▼────────────────────────────────────────┐
-│                     DOMAIN SERVICE LAYER  ← IEC 62304 scope      │
-│   vitals.c  │  alerts.c  │  patient.c  │  pw_hash.c  │  auth    │
-│                        monitor_lib (static library)               │
-└────────────────────────┬────────────────────────────────────────┘
-                         │ HAL interface  (hw_vitals.h)
-┌────────────────────────▼────────────────────────────────────────┐
-│                       HARDWARE LAYER                              │
-│           sim_vitals.c (current)  │  hw_driver.c (real HW)       │
-└─────────────────────────────────────────────────────────────────┘
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚                       PRESENTATION LAYER                         â”‚
+â”‚   Win32 GUI (current)  â”‚  Web SPA (future)  â”‚  Mobile (future)  â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¬â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+                         â”‚ HTTP / JSON REST   (Win32 uses direct calls)
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â–¼â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚                       API GATEWAY LAYER  (future)                â”‚
+â”‚           REST Server â€” libmongoose (single-header C)            â”‚
+â”‚           Endpoints: /vitals  /alerts  /patient  /auth           â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¬â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+                         â”‚ C function calls
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â–¼â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚                     DOMAIN SERVICE LAYER  â† IEC 62304 scope      â”‚
+â”‚   vitals.c  â”‚  alerts.c  â”‚  patient.c  â”‚  pw_hash.c  â”‚  auth    â”‚
+â”‚                        monitor_lib (static library)               â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¬â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+                         â”‚ HAL interface  (hw_vitals.h)
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â–¼â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚                       HARDWARE LAYER                              â”‚
+â”‚           sim_vitals.c (current)  â”‚  hw_driver.c (real HW)       â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
 ```
 
 ---
@@ -57,7 +57,7 @@ safety-critical business logic:
 | Authentication | `gui_users.c` | Account CRUD, role management, hashed credential store |
 
 **Constraints (IEC 62304 SYS-012):**
-- No heap allocation — all storage is static or stack.
+- No heap allocation â€” all storage is static or stack.
 - No OS-specific headers in domain code.
 - 100 % branch coverage required (enforced by `--coverage` + CI).
 
@@ -71,7 +71,7 @@ void hw_get_next_reading(VitalSigns *out); // called every ~2 s
 ```
 
 Current implementation: `sim_vitals.c` (20-entry clinical scenario table).  
-Production replacement: `hw_driver.c` — reads from a real medical sensor
+Production replacement: `hw_driver.c` â€” reads from a real medical sensor
 (serial, USB HID, ADC) with **zero changes** to any other file.
 
 ### 2.3 Application Services Layer
@@ -81,15 +81,15 @@ Cross-cutting concerns that live between domain and presentation:
 | Module | File | Responsibility |
 |--------|------|----------------|
 | Config persistence | `app_config.c` | Read/write `monitor.cfg` (sim mode state) |
-| Auth façade | `gui_auth.c` | Thin wrapper mapping legacy `auth_*` API to `gui_users.c` |
+| Auth faÃ§ade | `gui_auth.c` | Thin wrapper mapping legacy `auth_*` API to `gui_users.c` |
 
-### 2.4 API Gateway Layer *(planned — not yet implemented)*
+### 2.4 API Gateway Layer *(planned â€” not yet implemented)*
 
 To expose the domain to web and mobile clients, a thin REST adapter will
 wrap `monitor_lib`. Recommended implementation:
 
 - **Library**: [libmongoose](https://github.com/cesanta/mongoose) (single-header
-  embedded HTTP/WebSocket server — MIT licence, no dependencies).
+  embedded HTTP/WebSocket server â€” MIT licence, no dependencies).
 - **Build target**: `patient_monitor_api` executable (separate from GUI).
 - **Endpoints** (JSON):
 
@@ -107,7 +107,7 @@ a new client type. The certified domain layer remains unchanged.
 
 ### 2.5 Presentation Layer
 
-Current: **Win32 GUI** (`gui_main.c`) — a single-process C application that
+Current: **Win32 GUI** (`gui_main.c`) â€” a single-process C application that
 calls `monitor_lib` directly (no HTTP overhead for local use).
 
 Planned clients call the REST API:
@@ -136,19 +136,19 @@ Planned clients call the REST API:
 
 ```
 monitor_lib (C, certified)
-    │
-    ▼ linked into
-patient_monitor_api (C + mongoose.h)  ← single binary, runs on Windows/Linux
-    │ HTTP/JSON on localhost:8080
-    ▼
-React SPA (TypeScript + Vite)         ← served from the same binary as static files
-    │
-    ▼ (same API, remote endpoint)
+    â”‚
+    â–¼ linked into
+patient_monitor_api (C + mongoose.h)  â† single binary, runs on Windows/Linux
+    â”‚ HTTP/JSON on localhost:8080
+    â–¼
+React SPA (TypeScript + Vite)         â† served from the same binary as static files
+    â”‚
+    â–¼ (same API, remote endpoint)
 React Native app (iOS + Android)
 ```
 
 This lets the **certified C core run on the medical device hardware** while the
-UI runs on a tablet, phone, or browser — connected over local network or USB
+UI runs on a tablet, phone, or browser â€” connected over local network or USB
 ethernet.
 
 ---
@@ -157,11 +157,11 @@ ethernet.
 
 ```
 WM_TIMER (2 s)
-    └─► hw_get_next_reading(&v)      [HAL — sim_vitals.c]
-            └─► patient_add_reading(&patient, &v)  [domain]
-                    └─► generate_alerts(&latest, alerts, MAX_ALERTS)  [domain]
-                            └─► update_dashboard(hwnd)  [presentation]
-                                    └─► InvalidateRect → WM_PAINT → paint_tiles()
+    â””â”€â–º hw_get_next_reading(&v)      [HAL â€” sim_vitals.c]
+            â””â”€â–º patient_add_reading(&patient, &v)  [domain]
+                    â””â”€â–º generate_alerts(&latest, alerts, MAX_ALERTS)  [domain]
+                            â””â”€â–º update_dashboard(hwnd)  [presentation]
+                                    â””â”€â–º InvalidateRect â†’ WM_PAINT â†’ paint_tiles()
 ```
 
 ---
@@ -171,9 +171,9 @@ WM_TIMER (2 s)
 | Concern | Mechanism | Standard |
 |---------|-----------|----------|
 | Password storage | SHA-256 (FIPS 180-4), hex digest, never plaintext | SWR-SEC-004 |
-| File permissions | `_sopen_s(_S_IREAD\|_S_IWRITE)` — owner-only | CWE-732 |
+| File permissions | `_sopen_s(_S_IREAD\|_S_IWRITE)` â€” owner-only | CWE-732 |
 | Role enforcement | `ROLE_ADMIN` / `ROLE_CLINICAL` checked at every privileged action | SWR-SEC-002 |
-| Session | In-process `g_app.logged_role` — cleared on logout | SWR-SEC-001 |
+| Session | In-process `g_app.logged_role` â€” cleared on logout | SWR-SEC-001 |
 | Future API | JWT or session tokens over HTTPS (TLS 1.3) | OWASP API Top 10 |
 
 ---
@@ -182,11 +182,11 @@ WM_TIMER (2 s)
 
 | Milestone | Deliverable | Effort |
 |-----------|------------|--------|
-| **Current (v2.x)** | Win32 GUI, monitor_lib, HAL | — |
-| **v3.0 — REST API** | Add mongoose.h adapter + JSON serialisation | 2–3 weeks |
-| **v3.1 — Web client** | React SPA connecting to REST API | 3–4 weeks |
-| **v3.2 — Mobile** | React Native app (iOS + Android) | 4–6 weeks |
-| **v4.0 — Cloud** | API gateway → cloud FHIR store; real-time WebSocket alerts | 8+ weeks |
+| **Current (v2.x)** | Win32 GUI, monitor_lib, HAL | â€” |
+| **v3.0 â€” REST API** | Add mongoose.h adapter + JSON serialisation | 2â€“3 weeks |
+| **v3.1 â€” Web client** | React SPA connecting to REST API | 3â€“4 weeks |
+| **v3.2 â€” Mobile** | React Native app (iOS + Android) | 4â€“6 weeks |
+| **v4.0 â€” Cloud** | API gateway â†’ cloud FHIR store; real-time WebSocket alerts | 8+ weeks |
 
 ---
 
@@ -194,36 +194,36 @@ WM_TIMER (2 s)
 
 ```
 patient-vital-signs-monitor/
-├── include/              # Public C headers (domain + HAL + services)
-│   ├── vitals.h          # VitalSigns, AlertLevel, check_* API
-│   ├── alerts.h          # Alert, generate_alerts, overall_alert_level
-│   ├── patient.h         # PatientRecord, patient_* API
-│   ├── hw_vitals.h       # HAL interface (swap for real hardware)
-│   ├── gui_users.h       # Account management API
-│   ├── gui_auth.h        # Auth façade (backward compat)
-│   ├── pw_hash.h         # SHA-256 password hashing
-│   └── app_config.h      # Config persistence (sim mode)
-├── src/                  # Implementation
-│   ├── vitals.c          # Domain: vital sign classification
-│   ├── alerts.c          # Domain: alert generation
-│   ├── patient.c         # Domain: patient record
-│   ├── pw_hash.c         # Domain: SHA-256
-│   ├── gui_users.c       # Service: user account management
-│   ├── gui_auth.c        # Service: auth façade
-│   ├── app_config.c      # Service: config persistence
-│   ├── sim_vitals.c      # HAL: simulation back-end
-│   ├── gui_main.c        # Presentation: Win32 dashboard
-│   └── main.c            # CLI entry point
-├── tests/
-│   ├── unit/             # 293 unit tests
-│   └── integration/      # 14 integration tests
-├── dvt/                  # Design Verification Testing
-│   ├── DVT_Protocol.md   # DVT-001-REV-A
-│   ├── run_dvt.py        # Automated DVT runner
-│   └── results/          # Timestamped test reports
-├── requirements/         # SWR, SYS, UNS, TRACEABILITY
-├── docs/                 # Architecture, design notes
-└── .github/workflows/    # CI, DVT, CodeQL, static-analysis, release
+â”œâ”€â”€ include/              # Public C headers (domain + HAL + services)
+â”‚   â”œâ”€â”€ vitals.h          # VitalSigns, AlertLevel, check_* API
+â”‚   â”œâ”€â”€ alerts.h          # Alert, generate_alerts, overall_alert_level
+â”‚   â”œâ”€â”€ patient.h         # PatientRecord, patient_* API
+â”‚   â”œâ”€â”€ hw_vitals.h       # HAL interface (swap for real hardware)
+â”‚   â”œâ”€â”€ gui_users.h       # Account management API
+â”‚   â”œâ”€â”€ gui_auth.h        # Auth faÃ§ade (backward compat)
+â”‚   â”œâ”€â”€ pw_hash.h         # SHA-256 password hashing
+â”‚   â””â”€â”€ app_config.h      # Config persistence (sim mode)
+â”œâ”€â”€ src/                  # Implementation
+â”‚   â”œâ”€â”€ vitals.c          # Domain: vital sign classification
+â”‚   â”œâ”€â”€ alerts.c          # Domain: alert generation
+â”‚   â”œâ”€â”€ patient.c         # Domain: patient record
+â”‚   â”œâ”€â”€ pw_hash.c         # Domain: SHA-256
+â”‚   â”œâ”€â”€ gui_users.c       # Service: user account management
+â”‚   â”œâ”€â”€ gui_auth.c        # Service: auth faÃ§ade
+â”‚   â”œâ”€â”€ app_config.c      # Service: config persistence
+â”‚   â”œâ”€â”€ sim_vitals.c      # HAL: simulation back-end
+â”‚   â”œâ”€â”€ gui_main.c        # Presentation: Win32 dashboard
+â”‚   â””â”€â”€ main.c            # CLI entry point
+â”œâ”€â”€ tests/
+â”‚   â”œâ”€â”€ unit/             # 307 unit tests
+â”‚   â””â”€â”€ integration/      # 14 integration tests
+â”œâ”€â”€ dvt/                  # Design Verification Testing
+â”‚   â”œâ”€â”€ DVT_Protocol.md   # DVT-001-REV-A
+â”‚   â”œâ”€â”€ run_dvt.py        # Automated DVT runner
+â”‚   â””â”€â”€ results/          # Timestamped test reports
+â”œâ”€â”€ requirements/         # SWR, SYS, UNS, TRACEABILITY
+â”œâ”€â”€ docs/                 # Architecture, design notes
+â””â”€â”€ .github/workflows/    # CI, DVT, CodeQL, static-analysis, release
 ```
 
 ---
@@ -232,4 +232,4 @@ patient-vital-signs-monitor/
 
 | Rev | Date       | Author        | Description |
 |-----|------------|---------------|-------------|
-| A   | 2026-04-08 | vinu-engineer | Initial architecture document — v2.1.0 |
+| A   | 2026-04-08 | vinu-engineer | Initial architecture document â€” v2.1.0 |

--- a/docs/history/risk/60-make-clinician-idle-timeout-configurable.md
+++ b/docs/history/risk/60-make-clinician-idle-timeout-configurable.md
@@ -1,0 +1,246 @@
+## Risk Note: Issue 60
+
+Issue: `#60`  
+Branch: `feature/60-make-clinician-idle-timeout-configurable`
+
+## proposed change
+
+Add an administrator-configurable idle timeout for clinician session auto-lock
+or auto-logout behavior, using the existing local settings and config
+persistence model. The proposed scope is limited to access-control behavior and
+must not change alarm logic, vital-sign calculations, patient-data storage
+format, or authentication factors.
+
+Repository review on 2026-05-06 found existing login/logout, role-based
+settings access, and `monitor.cfg` persistence, but did not find an existing
+idle-timeout requirement or a visible idle-timeout implementation in
+`src/**`, `include/**`, or `requirements/**`. Treat this issue as a new
+session-control feature, not as a pure exposure of an already traced constant.
+
+## product hypothesis and intended user benefit
+
+The product hypothesis is credible: a fixed idle-timeout value can be too short
+for slower review workflows or too permissive for shared ward workstations.
+Allowing an administrator to configure the value can reduce repeated workflow
+interruptions while still limiting unattended patient-data exposure. The
+intended user benefit is local policy flexibility without changing any clinical
+interpretation, thresholds, alarms, or monitoring math.
+
+## source evidence quality
+
+Source evidence quality is moderate for the narrow claim that clinician
+authentication and session timeout/logout controls are normal product behavior
+in bedside-monitoring ecosystems, and low for choosing a safe timeout range or
+proving usability benefit in this repository.
+
+The issue cites public vendor material from:
+
+- Drager Vista IFU, which describes clinician auto logout when the configured
+  auto-logout time is reached.
+- Mindray public operator-manual resources showing clinician login/logout and
+  session-control flows in monitoring-viewer products.
+
+These sources are acceptable as untrusted product-discovery context only. They
+are not independent clinical evidence, not a substitute for local usability
+validation, and not a basis for copying vendor UX.
+
+## MVP boundary that avoids copying proprietary UX
+
+The MVP should use a simple local control in the existing settings surface,
+such as a numeric minutes field or constrained drop-down, persisted through the
+same local config mechanism already used for `monitor.cfg`. The design should
+avoid copying competitor screen layout, terminology, icons, warning copy, or
+workflow choreography. The MVP should exclude per-user policy, remote policy
+sync, fleet management, analytics, and any claim of enterprise access-control
+completeness.
+
+## clinical-safety boundary and claims that must not be made
+
+This change is an access-control feature, not a clinical feature. It must not
+be described as improving diagnosis, triage, alarm detection, or treatment
+quality. It must not alter alarm thresholds, suppress alarms, pause monitoring,
+change vital-sign acquisition cadence, or silently change patient context. It
+also must not be positioned as a complete HIPAA or security-compliance
+solution without broader system controls and validation.
+
+## whether the candidate is safe to send to Architect
+
+Yes, with constraints. The issue is specific enough for architecture and design
+work because it has a bounded user problem, an explicit non-clinical scope, and
+clear repo touchpoints in authentication, settings, and config persistence.
+However, the design spec must make the timeout semantics explicit instead of
+assuming that a new setting can simply reuse any current behavior.
+
+## medical-safety impact
+
+Medical-safety impact is indirect but real. A timeout that is too short can
+interrupt clinician review, force unnecessary re-authentication, and delay
+access to patient information during a monitoring workflow. A timeout that is
+too long can leave patient information visible on an unattended shared device.
+Because the requested change does not alter clinical calculations or alarm
+evaluation, the main harm mode is delayed access, confusion, or privacy
+exposure rather than direct treatment error. The feature remains suitable for
+design if the timeout range, default, privilege boundary, and expiry behavior
+are explicitly constrained.
+
+## security and privacy impact
+
+The intended security effect is positive if the feature enforces a sensible
+default and a bounded maximum duration. The new risks are:
+
+- a mis-set or invalid timeout value weakens session protection
+- a clinician-accessible setting weakens role-based access control
+- weak load/save validation allows `monitor.cfg` values that disable or bypass
+  the intended control
+
+Privacy impact is meaningful because unattended sessions can expose patient
+identifiers and current monitoring context on shared workstations. No new data
+collection, export, or sharing path is justified by this issue.
+
+## affected requirements or "none"
+
+Likely affected existing intent:
+
+- `UNS-013`
+- `UNS-016`
+- `SYS-013`
+- `SYS-016`
+- `SYS-017`
+- `SWR-GUI-002`
+- `SWR-GUI-008`
+- `SWR-GUI-009`
+- `SWR-GUI-010` if the new value is persisted in `monitor.cfg`
+
+New or updated requirement text will likely be needed for idle-timeout
+behavior, bounds, persistence, and RBAC. The issue should not rely only on
+informal extension of existing auth/settings prose.
+
+## intended use, user population, operating environment, and foreseeable misuse
+
+Intended use: allow an authorized ward administrator to configure how long a
+logged-in session may remain idle before the UI requires re-authentication.
+
+User population: ward administrators who manage local policy, and bedside
+clinicians who are subject to the configured timeout.
+
+Operating environment: shared local workstation or monitor terminal in a ward
+or bedside environment, where users may step away and multiple staff may share
+the same device.
+
+Foreseeable misuse:
+
+- setting the timeout too low for normal workflow and leaving it in production
+- setting the timeout to an effectively disabled value if bounds are weak
+- assuming the feature protects an unattended device without other local
+  physical and operational controls
+- assuming the feature changes alarms or patient monitoring behavior
+
+## severity, probability, initial risk, risk controls, verification method, residual risk, and residual-risk acceptability rationale
+
+Primary access-interruption hazard: timeout expires during active but low-input
+review, causing workflow delay.
+
+- Severity: moderate
+- Probability before controls: occasional
+- Initial risk: medium
+- Required controls: bounded range, safe default, clear units, explicit expiry
+  behavior, and validation that inactivity detection matches the intended use
+- Verification method: unit tests for bounds and persistence, GUI tests for
+  admin-only editing, and manual idle-expiry walkthroughs
+- Residual risk: low to medium-low
+
+Primary privacy hazard: timeout is too long or invalid, leaving patient data
+visible on an unattended device.
+
+- Severity: moderate
+- Probability before controls: occasional
+- Initial risk: medium
+- Required controls: enforced minimum/maximum duration, reject invalid config
+  values on load, and no "disable timeout" MVP option without human approval
+- Verification method: persistence tests, negative tests for invalid values,
+  and manual unattended-session expiry checks
+- Residual risk: low
+
+Residual-risk acceptability rationale: acceptable for this pilot if the feature
+remains local, admin-controlled, bounded, and clearly separated from alarm and
+patient-data behavior. The risk is not acceptable if the implementation allows
+clinical users to edit the setting, accepts invalid config values, or uses an
+expiry path that silently changes patient context.
+
+## hazards and failure modes
+
+- An invalid or out-of-range persisted value creates an immediate logout loop
+  or disables the timeout in practice.
+- The timeout expires while the user is reviewing data with low input activity,
+  causing avoidable delay.
+- The expiry path behaves differently from the intended secure state and leaves
+  user or patient context partially exposed.
+- The feature is placed in a settings area reachable by clinical users and
+  weakens role-based access control.
+- The design reuses the current explicit logout path without deciding whether
+  clearing session data on idle expiry is acceptable.
+- Timeout handling interferes with monitoring timers, alarms, or future device
+  mode transitions.
+
+## existing controls
+
+- `SYS-013` and `SWR-GUI-002` already define explicit login/logout behavior and
+  session clearing on logout.
+- `SYS-017`, `SWR-GUI-008`, and `SWR-GUI-009` already define role-based
+  privilege boundaries and an admin-specific user-management surface.
+- `src/gui_main.c` already builds role-aware settings tabs and privileged
+  account-management actions.
+- `src/app_config.c` and `include/app_config.h` already provide local
+  `monitor.cfg` persistence patterns for settings values.
+- The issue explicitly keeps clinical thresholds, alarms, patient data, remote
+  sync, and new authentication factors out of scope.
+
+## required design controls
+
+- Define the idle-expiry behavior explicitly as either full logout or
+  re-authentication lock, and do not leave that choice implicit.
+- Restrict editing of the timeout value to `ROLE_ADMIN`; clinicians must not be
+  able to change it through UI navigation or direct config-path misuse.
+- Enforce the approved range on both UI save and config-file load. Reject zero,
+  negative, non-numeric, and out-of-range values.
+- Use an explicit unit in minutes and keep a human-approved default. Do not add
+  a "never timeout" option in the MVP unless a human owner approves it.
+- Keep the setting local to the device. No remote policy, account sync, or
+  hidden per-user behavior should be added in this issue.
+- Do not alter alarm logic, sampling cadence, patient-record semantics, or
+  authentication-factor rules as part of this work.
+- Update requirements and traceability explicitly so the timeout behavior is
+  testable and auditable rather than implied.
+
+## validation expectations
+
+- Unit tests for timeout parsing, bounds enforcement, default fallback, and
+  persistence/load behavior in `monitor.cfg`
+- UI verification that only admin sessions can edit the setting
+- Manual verification that the configured value persists across restart
+- Manual verification that idle expiry leads to the specified secure state and
+  that re-authentication behavior is consistent
+- Regression verification that alarms, patient vitals logic, and unrelated
+  settings behavior are unchanged
+- Negative testing for malformed config values and minimum/maximum boundary
+  inputs
+
+## residual risk for this pilot
+
+Residual pilot risk is low if the setting is bounded, admin-only, and kept
+strictly separate from clinical monitoring behavior. Residual risk rises to
+unacceptable if the implementation silently clears patient context on timeout
+without an explicit product decision, or if invalid config values can bypass
+the timeout policy.
+
+## human owner decision needed, if any
+
+Yes.
+
+- Approve the allowed timeout range and default value for the pilot. The issue
+  suggests 1-30 minutes, which is plausible but not yet approved by repo
+  requirements.
+- Decide whether idle expiry is a full logout that clears session data or a
+  lock/re-auth flow that preserves the active patient context.
+- Confirm whether clinicians may view the configured value read-only or whether
+  the setting should be hidden entirely outside admin flows.

--- a/docs/history/specs/60-make-clinician-idle-timeout-configurable.md
+++ b/docs/history/specs/60-make-clinician-idle-timeout-configurable.md
@@ -1,0 +1,358 @@
+# Design Spec: Make clinician idle timeout configurable
+
+Issue: `#60`
+Branch: `feature/60-make-clinician-idle-timeout-configurable`
+Spec path: `docs/history/specs/60-make-clinician-idle-timeout-configurable.md`
+
+## Problem
+
+Issue #60 asks for an administrator-configurable idle timeout for clinician
+session auto-lock. The current repository does not expose a configurable idle
+timeout and, more importantly, does not show an existing traced idle-timeout
+requirement or visible idle-timeout implementation in `src/**`,
+`include/**`, or `requirements/**`.
+
+Current code supports:
+
+- explicit login and logout
+- role-based settings access
+- local `monitor.cfg` persistence for a small set of GUI settings
+
+Current code does not support:
+
+- idle detection tied to authenticated sessions
+- lock-versus-logout semantics for idle expiry
+- bounded timeout persistence and validation
+- a settings control for session timeout policy
+
+Without a narrow design, implementation could easily pick the wrong secure
+state on expiry, expose the setting to clinical users, or add config parsing
+that accepts invalid values and weakens access control.
+
+## Goal
+
+Add a narrow, traceable session-idle control that lets an administrator
+configure how long an authenticated application session may remain inactive
+before the UI enters a secure locked state.
+
+The intended implementation outcome is:
+
+- one local timeout value, in minutes, stored in `monitor.cfg`
+- admin-only editing of that value
+- enforced minimum, maximum, and default values
+- idle expiry that locks the interactive UI and requires re-authentication
+- no change to alarms, vital-sign calculations, patient-record semantics, or
+  monitoring cadence
+
+For this design, the recommended bounds are:
+
+- minimum: `1` minute
+- maximum: `30` minutes
+- default/fallback: `5` minutes
+
+## Non-goals
+
+- No new authentication factor, SSO, badge login, or remote identity flow.
+- No per-user or per-role timeout values in the MVP.
+- No remote policy sync, fleet management, audit export, or analytics.
+- No "never timeout" or `0 = disabled` option in the MVP.
+- No reuse of the existing explicit logout path as the idle-expiry behavior.
+- No change to alarm limits, NEWS2, vital classification, patient storage,
+  live-monitoring cadence, or hardware-abstraction behavior.
+- No production-code changes in this architect role; only the design spec is
+  added on this branch.
+
+## Intended use impact, user population, operating environment, and foreseeable misuse
+
+Intended use impact:
+
+- The feature extends access-control behavior for authenticated sessions on the
+  local workstation.
+- It does not change clinical interpretation or monitoring behavior.
+
+User population:
+
+- ward administrators who configure the timeout
+- authenticated bedside clinicians and administrators whose sessions are
+  subject to the configured timeout
+
+Operating environment:
+
+- shared local Windows workstation or monitor terminal in a ward or bedside
+  setting
+
+Foreseeable misuse:
+
+- an administrator sets the timeout too low and causes avoidable workflow
+  interruption
+- an administrator sets the timeout too high and weakens unattended-session
+  protection
+- a malformed `monitor.cfg` value effectively disables or destabilizes the
+  feature if validation is weak
+- passive dashboard updates are incorrectly treated as user activity, so the
+  session never locks in simulation mode
+- implementation silently clears patient context on timeout by reusing logout
+  instead of an explicit lock flow
+
+## Current behavior
+
+- `src/gui_main.c` implements explicit login and logout only. Logout destroys
+  the dashboard window, clears session fields, clears patient state, and
+  returns to the login window.
+- `src/gui_main.c` already enforces role-based settings navigation. Admin users
+  receive the full settings surface; clinical users receive a reduced tab set.
+- `src/app_config.c` and `include/app_config.h` persist `sim_enabled` and
+  `language` in `monitor.cfg`, using dedicated load/save helpers rather than a
+  broad config object.
+- `tests/unit/test_config.cpp` already covers basic `monitor.cfg` persistence
+  and malformed-file fallback behavior for existing keys.
+- Repository search and the issue-60 risk note both indicate that idle-timeout
+  behavior is not currently implemented or traced as an approved requirement.
+
+## Proposed change
+
+Implement issue #60 as a new local session-control feature with the following
+design decisions.
+
+1. Treat idle timeout as a new authenticated-session behavior, not as exposure
+   of an existing hidden constant.
+
+2. Apply the timeout to all authenticated dashboard sessions, including admin
+   and clinical users. Editing the value remains admin-only.
+
+3. Use a dedicated locked-session state on idle expiry, not the existing
+   logout flow. The locked state shall:
+   - hide or fully obscure patient-identifying and patient-monitoring content
+   - block dashboard and settings interaction until re-authentication succeeds
+   - preserve the current in-memory patient session and monitoring state
+   - leave explicit user-initiated Logout behavior unchanged
+
+4. Preserve monitoring and alarm behavior while locked. Idle expiry must not:
+   - stop simulation/device timers
+   - pause alarm evaluation
+   - clear the patient record
+   - change the current patient context
+
+5. Add a separate session-idle timer path in `src/gui_main.c` that runs
+   regardless of simulation mode. Do not reuse `TIMER_SIM` as the only expiry
+   clock because idle locking must still work when simulation is disabled.
+
+6. Track app-local user activity, not passive redraws. Only keyboard, mouse,
+   and direct authenticated-window interaction should reset the inactivity
+   timestamp. Automatic `WM_TIMER` updates, repaint traffic, and simulated
+   vital refreshes must not count as activity.
+
+7. Add a small pure helper module for policy and expiry logic, for example:
+   - `include/session_timeout.h`
+   - `src/session_timeout.c`
+
+   That helper should own:
+   - approved constants (`min`, `max`, `default`)
+   - validation/clamp-or-default behavior for persisted values
+   - a pure "expired or not" decision based on elapsed ticks
+
+   This keeps bounds and expiry semantics unit-testable instead of burying them
+   entirely inside Win32 message handling.
+
+8. Extend config persistence using the current module pattern rather than a
+   large refactor. Recommended approach:
+   - add `idle_timeout_minutes=<N>` to `monitor.cfg`
+   - add dedicated `app_config_load_idle_timeout_minutes()` and
+     `app_config_save_idle_timeout_minutes()` helpers
+   - preserve existing keys (`sim_enabled`, `language`) on save
+   - reject missing, zero, negative, non-numeric, and out-of-range values by
+     falling back to the approved default
+
+9. Add an admin-only session/security settings surface in `src/gui_main.c`.
+   Recommended MVP shape:
+   - a new admin-only Settings tab such as `Session` or `Security`
+   - a constrained numeric input or drop-down in minutes
+   - inline text showing the allowed range and that the value applies to future
+     idle detection immediately after save
+
+   Clinical users should not be able to edit the value and should not gain a
+   new navigation path into admin controls. For the MVP, do not add a
+   clinician-visible editor.
+
+10. Introduce a dedicated lock UI path in `src/gui_main.c`, such as a
+    `PVM_Lock` modal window or lock overlay, instead of overloading the
+    existing login window. Successful unlock should:
+    - re-authenticate the current user with username/password
+    - restore the dashboard/settings context without clearing patient data
+    - reset the inactivity timestamp
+
+11. Keep the implementation local and static-memory-compatible. No heap-backed
+    session objects, remote callbacks, or persistence outside `monitor.cfg`
+    should be introduced for this issue.
+
+## Files expected to change
+
+Expected implementation files:
+
+- `requirements/UNS.md`
+- `requirements/SYS.md`
+- `requirements/SWR.md`
+- `requirements/TRACEABILITY.md`
+- `include/app_config.h`
+- `src/app_config.c`
+- `include/session_timeout.h`
+- `src/session_timeout.c`
+- `src/gui_main.c`
+- `include/localization.h`
+- `src/localization.c`
+- `CMakeLists.txt`
+- `tests/CMakeLists.txt`
+- `tests/unit/test_config.cpp`
+- `tests/unit/test_session_timeout.cpp`
+
+Expected files to inspect and likely leave unchanged:
+
+- `src/gui_auth.c`
+- `include/gui_auth.h`
+- `src/gui_users.c`
+- `tests/unit/test_auth.cpp`
+- `docs/history/risk/60-make-clinician-idle-timeout-configurable.md`
+
+Files that should not change:
+
+- `src/vitals.c`
+- `src/alerts.c`
+- `src/patient.c`
+- `src/news2.c`
+- `src/alarm_limits.c`
+- `tests/integration/**`
+- CI/release workflow files unless implementation discovers a build-target
+  update is required for the new helper module
+
+## Requirements and traceability impact
+
+This issue should not rely on vague extension of current auth wording. It needs
+explicit requirement updates.
+
+Recommended traceability shape:
+
+- extend `UNS-013` to cover unattended-session protection after authentication
+- extend `UNS-016` to cover admin-only configuration of access-control policy
+- add `SYS-020` for configurable idle session locking with bounded timeout,
+  secure locked state, and local persistence requirements
+- add `SWR-GUI-013` for the admin session-timeout settings UI and persistence
+- add `SWR-SEC-005` for inactivity tracking, expiry enforcement, locked-state
+  behavior, and re-authentication semantics
+
+Recommended implementation/verification mapping:
+
+- `SWR-GUI-013`
+  - implementation: `src/gui_main.c`, `src/app_config.c`, `src/localization.c`
+  - verification: `tests/unit/test_config.cpp`, manual admin-settings GUI
+    verification
+
+- `SWR-SEC-005`
+  - implementation: `src/session_timeout.c`, `src/gui_main.c`
+  - verification: `tests/unit/test_session_timeout.cpp`, manual idle-expiry and
+    unlock walkthroughs
+
+`requirements/TRACEABILITY.md` will need new forward and backward rows for the
+new SWR(s), plus updated coverage counts if the implementation adds a new unit
+test suite.
+
+## Medical-safety, security, and privacy impact
+
+Medical-safety impact is indirect but real. A timeout that is too short can
+interrupt review and delay access to patient information. A timeout that is too
+long can leave patient data exposed on an unattended shared device. The design
+mitigates that by using:
+
+- bounded values
+- an admin-only editor
+- explicit lock semantics that preserve monitoring behavior
+- strict fallback on invalid config input
+
+Security impact is positive if implemented as designed. The feature improves
+local unattended-session protection, but only if:
+
+- invalid config values cannot disable the control
+- clinicians cannot edit the timeout
+- idle expiry leads to a true locked state that requires re-authentication
+
+Privacy impact is meaningful because patient identity and current monitoring
+context may be visible on shared devices. The lock UI must obscure patient data
+until unlock succeeds.
+
+Because this issue touches authentication and persistence, the implementation
+review must explicitly confirm that idle expiry does not silently broaden data
+access, change logout semantics, or alter patient-monitoring behavior.
+
+## AI/ML impact assessment
+
+This change does not add, change, remove, or depend on any AI-enabled device
+software function.
+
+- No model is introduced.
+- No model input/output path changes.
+- No human-in-the-loop AI decision changes.
+- No dataset, bias, monitoring, or PCCP implications apply.
+
+## Validation plan
+
+Build and automated verification:
+
+```powershell
+cmake -S . -B build -G Ninja -DBUILD_TESTS=ON
+cmake --build build
+build/tests/test_unit.exe
+```
+
+Targeted automated checks expected after implementation:
+
+```powershell
+build/tests/test_unit.exe --gtest_filter=ConfigTest.*:SessionTimeout*.*
+```
+
+Targeted text/config inspection:
+
+```powershell
+rg -n "idle_timeout|session timeout|locked" requirements/SYS.md requirements/SWR.md requirements/TRACEABILITY.md src/gui_main.c src/app_config.c include/session_timeout.h src/session_timeout.c tests/unit/test_config.cpp tests/unit/test_session_timeout.cpp
+git diff --stat
+```
+
+Manual verification:
+
+1. Log in as admin and confirm the session-timeout setting is visible only in
+   the admin settings surface.
+2. Save boundary values `1` and `30` minutes and verify they persist across
+   application restart.
+3. Attempt invalid values (`0`, negative, non-numeric, above max) and verify
+   the app stores or loads the approved default instead of accepting them.
+4. Leave the authenticated UI idle until expiry and verify:
+   - the UI locks
+   - patient-identifying content is obscured
+   - monitoring continues in the background
+   - alarms and current patient context are unchanged
+5. Unlock with valid credentials and verify the same patient session resumes.
+6. Verify an incorrect unlock password does not expose which field was wrong.
+7. Verify clinical users cannot edit the setting or reach the admin-only
+   session configuration path.
+
+Regression focus:
+
+- explicit logout still clears session and returns to login
+- simulation mode behavior is unchanged apart from no longer preventing idle
+  locking through passive timer traffic
+- language, alarm-limit, and other settings persistence remain intact
+
+## Rollback or failure handling
+
+If implementation cannot preserve patient context behind a locked state without
+an unexpectedly broad refactor, stop and split the work rather than silently
+falling back to full logout on idle expiry.
+
+If the product owner rejects the recommended `1..30` minute range or `5` minute
+default, update the requirements/spec before implementation rather than
+hard-coding unapproved values.
+
+If bounded validation cannot be added without destabilizing the current
+`monitor.cfg` helpers, revert the partial timeout changes and keep the branch in
+documentation/design state until the config approach is corrected.
+
+If implementation discovers a need for role-specific or per-user timeout
+policies, do not expand this issue in place. Treat that as a follow-on feature.

--- a/include/app_config.h
+++ b/include/app_config.h
@@ -2,8 +2,9 @@
  * @file app_config.h
  * @brief Application configuration persistence interface.
  *
- * Provides save/load of run-time configuration (currently only the
- * sim_enabled flag) to/from a plain-text file named APP_CFG_FILENAME.
+ * Provides save/load of run-time configuration (simulation mode, language,
+ * and clinician idle timeout) to/from a plain-text file named
+ * APP_CFG_FILENAME.
  * The file is located in the same directory as the running executable
  * unless overridden via app_config_set_path() (intended for unit tests).
  *
@@ -93,6 +94,34 @@ int app_config_load_language(void);
  * @req SWR-GUI-012
  */
 int app_config_save_language(int language);
+
+/**
+ * @brief Load the persisted clinician idle timeout from the configuration file.
+ *
+ * Reads the "idle_timeout_minutes=N" line from the config file. Missing,
+ * malformed, zero, negative, and out-of-range values fall back to the
+ * approved default.
+ *
+ * @return Idle timeout in minutes.
+ *
+ * @req SWR-GUI-014
+ * @req SWR-SEC-005
+ */
+int app_config_load_idle_timeout_minutes(void);
+
+/**
+ * @brief Save the clinician idle timeout to the configuration file.
+ *
+ * Preserves existing simulation-mode and language settings. Invalid timeout
+ * values are replaced with the approved default before persistence.
+ *
+ * @param minutes  Requested idle timeout in minutes.
+ * @return 1 on success, 0 on failure.
+ *
+ * @req SWR-GUI-014
+ * @req SWR-SEC-005
+ */
+int app_config_save_idle_timeout_minutes(int minutes);
 
 #ifdef __cplusplus
 }

--- a/include/session_timeout.h
+++ b/include/session_timeout.h
@@ -1,0 +1,35 @@
+/**
+ * @file session_timeout.h
+ * @brief Idle session-timeout policy helpers.
+ *
+ * Owns the approved timeout bounds plus pure helpers for validation and
+ * elapsed-time expiry decisions.
+ *
+ * @req SWR-SEC-005
+ */
+
+#ifndef SESSION_TIMEOUT_H
+#define SESSION_TIMEOUT_H
+
+#include <stdint.h>
+
+#define SESSION_TIMEOUT_MIN_MINUTES 1
+#define SESSION_TIMEOUT_MAX_MINUTES 30
+#define SESSION_TIMEOUT_DEFAULT_MINUTES 5
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int session_timeout_is_valid_minutes(int minutes);
+int session_timeout_normalize_minutes(int minutes);
+uint32_t session_timeout_duration_ms(int minutes);
+int session_timeout_has_expired(uint32_t last_activity_tick,
+                                uint32_t now_tick,
+                                int minutes);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SESSION_TIMEOUT_H */

--- a/requirements/SWR.md
+++ b/requirements/SWR.md
@@ -1,8 +1,8 @@
 # Software Requirements Specification (SWR)
 
-**Document ID:** SWR-001-REV-M
+**Document ID:** SWR-001-REV-N
 **Project:** Patient Vital Signs Monitor
-**Version:** 2.7.0
+**Version:** 2.8.0
 **Date:** 2026-05-06
 **Status:** Approved
 **Standard:** IEC 62304 §5.2
@@ -717,6 +717,55 @@ session event label string
 
 ---
 
+### SWR-SEC-005 â€” Idle Timeout Enforcement and Locked-Session Reauthentication
+**Requirement:** The idle session-timeout layer shall:
+1. Accept only timeout values in the approved range `1..30` minutes and
+   normalize all other values to the default `5` minutes.
+2. Track authenticated user activity from dashboard and authenticated
+   settings-dialog keyboard, mouse, and command interaction only. Passive
+   timer updates, redraws, and simulation refreshes shall not reset the timer.
+3. Detect idle expiry from elapsed ticks without heap allocation and remain
+   correct across tick-counter wraparound.
+4. On expiry, close any open authenticated modal dialogs, obscure the
+   dashboard by switching to a dedicated locked-session window, and preserve
+   the current patient and monitoring state in memory.
+5. Require the same authenticated username and password to unlock the session.
+   Authentication failures shall display a generic error and shall not reveal
+   which field was incorrect.
+6. Leave explicit user-initiated Logout behavior unchanged: Logout shall still
+   clear session data and return to the login screen.
+
+**Traces to:** SYS-022
+**Implemented in:** `src/session_timeout.c` â€” validation and expiry helpers;
+`src/gui_main.c` â€” idle timer, lock window, unlock flow
+**Verified by:** `tests/unit/test_session_timeout.cpp` â€” `SessionTimeout*.*`
+(7 tests); manual GUI review (`GUI-MAN-07`)
+
+---
+
+### SWR-GUI-014 â€” Admin Session Timeout Settings and Persistence
+
+**Requirement:** The Settings panel for `ROLE_ADMIN` sessions shall provide a
+dedicated Session tab for configuring the clinician idle timeout. The tab shall:
+
+1. Display the current timeout value in minutes.
+2. Accept only a single local timeout value that applies to all authenticated
+   sessions on the workstation.
+3. Persist the value to `monitor.cfg` using the key
+   `idle_timeout_minutes=<N>`.
+4. Apply the saved value immediately after the user clicks **Apply & Save**.
+5. Normalize missing, malformed, zero, negative, and out-of-range values to
+   the approved default `5` minutes when loading or saving.
+6. Remain inaccessible to `ROLE_CLINICAL` users.
+
+**Traces to:** SYS-022
+**Implemented in:** `src/gui_main.c` â€” Session tab and admin-only editor;
+`src/app_config.c` â€” `idle_timeout_minutes` persistence helpers
+**Verified by:** `tests/unit/test_config.cpp` â€” `ConfigTest.*` (17 tests);
+manual GUI review (`GUI-MAN-07`)
+
+---
+
 ## Revision History
 
 | Rev | Date       | Author          | Description          |
@@ -734,3 +783,4 @@ session event label string
 | K   | 2026-05-05 | Codex implementer | Restored defensible SYS-level traceability for SWR-VIT-008 and SWR-NEW-001; no clinical behavior changes |
 | L   | 2026-05-05 | Codex implementer | Added SWR-PAT-007/008 and SWR-GUI-013 for session alarm event review |
 | M   | 2026-05-06 | Codex implementer | Added explicit session-reset disclosure expectations for session review surfaces |
+| N   | 2026-05-06 | Codex implementer | Added SWR-SEC-005 and SWR-GUI-014 for configurable idle session locking |

--- a/requirements/SYS.md
+++ b/requirements/SYS.md
@@ -1,9 +1,9 @@
 # System Requirements Specification (SYS)
 
-**Document ID:** SYS-001-REV-F
+**Document ID:** SYS-001-REV-G
 **Project:** Patient Vital Signs Monitor
 **Version:** 1.0.0
-**Date:** 2026-05-05
+**Date:** 2026-05-06
 **Status:** Approved
 **Standard:** 21 CFR 820.30(d) / IEC 62304 §5.1
 
@@ -256,6 +256,22 @@ events have been recorded.
 
 ---
 
+### SYS-022 â€” Configurable Idle Session Locking
+**Requirement:** The system shall apply a locally persisted idle timeout to all
+authenticated dashboard sessions. The timeout shall be configurable only by
+`ROLE_ADMIN`, shall use minutes as its unit, shall accept only values in the
+approved range `1..30`, and shall fall back to the default value `5` when a
+persisted value is missing, malformed, zero, negative, or out of range. When
+no qualifying user interaction occurs for the configured duration, the system
+shall enter a locked state that obscures patient-monitoring content, blocks
+dashboard and settings interaction, preserves the active patient and monitoring
+state, and requires the same authenticated user to re-enter username and
+password before access resumes. Idle locking shall not stop monitoring timers,
+alarm evaluation, or patient-session storage.
+**Traces to:** UNS-013, UNS-016
+
+---
+
 ## Revision History
 
 | Rev | Date       | Author          | Description          |
@@ -266,3 +282,4 @@ events have been recorded.
 | D   | 2026-04-07 | vinu-engineer   | Added SYS-016 (multi-user accounts), SYS-017 (RBAC) |
 | E   | 2026-05-05 | Codex implementer | Added SYS-018 (RR) and SYS-019 (NEWS2) to restore defensible traceability for existing clinical requirements |
 | F   | 2026-05-05 | Codex implementer | Added SYS-020 and SYS-021 for session alarm event review |
+| G   | 2026-05-06 | Codex implementer | Added SYS-022 for configurable idle session locking |

--- a/requirements/TRACEABILITY.md
+++ b/requirements/TRACEABILITY.md
@@ -1,11 +1,11 @@
-# Requirements Traceability Matrix (RTM)
+﻿# Requirements Traceability Matrix (RTM)
 
-**Document ID:** RTM-001-REV-L
+**Document ID:** RTM-001-REV-M
 **Project:** Patient Vital Signs Monitor
-**Version:** 2.7.0
+**Version:** 2.8.0
 **Date:** 2026-05-06
 **Status:** Approved
-**Standard:** IEC 62304 §5.7.3 / FDA SW Validation Guidance
+**Standard:** IEC 62304 Â§5.7.3 / FDA SW Validation Guidance
 
 ---
 
@@ -16,24 +16,27 @@ traceability chain:
 
 ```
 User Need (UNS)
-    └── System Requirement (SYS)
-            └── Software Requirement (SWR)
-                    └── Implementation (file : function)
-                            └── Unit Tests
-                            └── Integration Tests
+    â””â”€â”€ System Requirement (SYS)
+            â””â”€â”€ Software Requirement (SWR)
+                    â””â”€â”€ Implementation (file : function)
+                            â””â”€â”€ Unit Tests
+                            â””â”€â”€ Integration Tests
 ```
 
-A gap in any column is a compliance finding — every SWR must have
+A gap in any column is a compliance finding â€” every SWR must have
 implementation and test coverage, and every UNS must reach at least one SWR.
 
 ---
 
-## Section 1 — Forward Traceability (UNS → Test)
+## Section 1 â€” Forward Traceability (UNS â†’ Test)
 
-> Reading direction: left to right — from user need down to verification evidence.
+> Reading direction: left to right â€” from user need down to verification evidence.
 
 | UNS | SYS | SWR | Implementation | Unit Tests | Integration Tests |
 |-----|-----|-----|----------------|------------|-------------------|
+| UNS-013, UNS-016 | SYS-022 | SWR-GUI-014 | `gui_main.c`, `app_config.c` : admin Session tab, `monitor.cfg` idle-timeout persistence | `ConfigTest.*` (17 tests) + manual GUI review (`GUI-MAN-07`) | â€” |
+| UNS-013, UNS-016 | SYS-022 | SWR-SEC-005 | `session_timeout.c`, `gui_main.c` : timeout bounds, idle timer, lock/unlock flow | `SessionTimeout*.*` (7 tests) + manual GUI review (`GUI-MAN-07`) | â€” |
+
 | UNS-001 | SYS-001 | SWR-VIT-001 | `vitals.c` : `check_heart_rate()` | `HeartRate.*` (14 tests) | `REQ_INT_ESC_002`, `REQ_INT_ESC_005` |
 | UNS-002 | SYS-002 | SWR-VIT-002 | `vitals.c` : `check_blood_pressure()` | `BloodPressure.*` (12 tests) | `REQ_INT_ESC_003` |
 | UNS-003 | SYS-003 | SWR-VIT-003 | `vitals.c` : `check_temperature()` | `Temperature.*` (10 tests) | `REQ_INT_MON_002`, `REQ_INT_MON_003` |
@@ -41,50 +44,51 @@ implementation and test coverage, and every UNS must reach at least one SWR.
 | UNS-005, UNS-006 | SYS-006 | SWR-VIT-005 | `vitals.c` : `overall_alert_level()` | `OverallAlert.*` (5 tests) | `REQ_INT_MON_002`, `REQ_INT_MON_003`, `REQ_INT_MON_004` |
 | UNS-007 | SYS-007 | SWR-VIT-006 | `vitals.c` : `calculate_bmi()`, `bmi_category()` | `BMI.*` (12 tests) | `REQ_INT_MON_001` |
 | UNS-005, UNS-006, UNS-010 | SYS-005, SYS-011 | SWR-VIT-007 | `vitals.c` : `alert_level_str()` | `AlertStr.*` (4 tests) | All integration tests |
-| UNS-005, UNS-006, UNS-014, UNS-015 | SYS-018 | SWR-VIT-008 | `vitals.c` : `check_respiration_rate()` | `RespRate.*` (12 tests), `OverallAlert.SWR_VIT_008_*` (3 tests) | — |
-| UNS-005, UNS-006, UNS-010, UNS-014 | SYS-019 | SWR-NEW-001 | `news2.c` : `news2_calculate()` | `News2HR.*`, `News2RR.*`, `News2SpO2.*`, `News2SBP.*`, `News2Temp.*`, `News2Calc.*` (53 tests) | — |
-| UNS-005, UNS-006 | SYS-002, SYS-003 | SWR-ALM-001 | `alarm_limits.c` : `alarm_limits_defaults()`, `alarm_check_*()` | `AlarmLimitsTest.*` (31 tests) | — |
-| UNS-001, UNS-009 | SYS-001, SYS-002 | SWR-TRD-001 | `trend.c` : `trend_direction()`, `trend_extract_*()` | `TrendDirection.*`, `TrendExtract.*` (18 tests) | — |
-| UNS-015 | SYS-015 | SWR-GUI-010 | `gui_main.c`, `app_config.c` : sim toggle + persistence | Manual GUI review + `ConfigTest.*` support (10 persistence checks) | — |
-| UNS-015 | SYS-005 | SWR-GUI-011 | `gui_main.c` : rolling message in sim mode (`paint_status_banner()`, scroll offset) | Manual visual review | — |
-| UNS-014 | SYS-014 | SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : language tab, selector strings, `monitor.cfg` persistence/load | `LocalizationTest.*` (8 tests) + supplemental `DVT-GUI-16` | — |
+| UNS-005, UNS-006, UNS-014, UNS-015 | SYS-018 | SWR-VIT-008 | `vitals.c` : `check_respiration_rate()` | `RespRate.*` (12 tests), `OverallAlert.SWR_VIT_008_*` (3 tests) | â€” |
+| UNS-005, UNS-006, UNS-010, UNS-014 | SYS-019 | SWR-NEW-001 | `news2.c` : `news2_calculate()` | `News2HR.*`, `News2RR.*`, `News2SpO2.*`, `News2SBP.*`, `News2Temp.*`, `News2Calc.*` (53 tests) | â€” |
+| UNS-005, UNS-006 | SYS-002, SYS-003 | SWR-ALM-001 | `alarm_limits.c` : `alarm_limits_defaults()`, `alarm_check_*()` | `AlarmLimitsTest.*` (31 tests) | â€” |
+| UNS-001, UNS-009 | SYS-001, SYS-002 | SWR-TRD-001 | `trend.c` : `trend_direction()`, `trend_extract_*()` | `TrendDirection.*`, `TrendExtract.*` (18 tests) | â€” |
+| UNS-015 | SYS-015 | SWR-GUI-010 | `gui_main.c`, `app_config.c` : sim toggle + persistence | Manual GUI review + `ConfigTest.*` support (10 persistence checks) | â€” |
+| UNS-015 | SYS-005 | SWR-GUI-011 | `gui_main.c` : rolling message in sim mode (`paint_status_banner()`, scroll offset) | Manual visual review | â€” |
+| UNS-014 | SYS-014 | SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : language tab, selector strings, `monitor.cfg` persistence/load | `LocalizationTest.*` (8 tests) + supplemental `DVT-GUI-16` | â€” |
 | UNS-005, UNS-006 | SYS-005 | SWR-ALT-001 | `alerts.c` : `generate_alerts()` | `REQ_ALT_002_*` (4 tests) | `REQ_INT_MON_004`, `REQ_INT_ESC_002`, `REQ_INT_ESC_003` |
 | UNS-005 | SYS-005 | SWR-ALT-002 | `alerts.c` : `generate_alerts()` | `REQ_ALT_001_*` (1 test) | `REQ_INT_ESC_004` |
-| UNS-011 | SYS-012 | SWR-ALT-003 | `alerts.c` : `generate_alerts()` | `REQ_ALT_004_*` (2 tests) | — |
-| UNS-005, UNS-006 | SYS-005 | SWR-ALT-004 | `alerts.c` : `generate_alerts()` via `PUSH_ALERT` | `REQ_ALT_005_*` (2 tests) | — |
+| UNS-011 | SYS-012 | SWR-ALT-003 | `alerts.c` : `generate_alerts()` | `REQ_ALT_004_*` (2 tests) | â€” |
+| UNS-005, UNS-006 | SYS-005 | SWR-ALT-004 | `alerts.c` : `generate_alerts()` via `PUSH_ALERT` | `REQ_ALT_005_*` (2 tests) | â€” |
 | UNS-008 | SYS-008, SYS-012 | SWR-PAT-001 | `patient.c` : `patient_init()` | `PatientInit.*` (3 tests) | `REQ_INT_MON_001`, `REQ_INT_MON_006` |
 | UNS-009, UNS-011 | SYS-009, SYS-010 | SWR-PAT-002 | `patient.c` : `patient_add_reading()` | `PatientAddReading.*` (5 tests) | `REQ_INT_MON_002`, `REQ_INT_MON_005`, `REQ_INT_MON_006` |
 | UNS-009 | SYS-009 | SWR-PAT-003 | `patient.c` : `patient_latest_reading()` | `PatientLatestReading.*` (2 tests) | `REQ_INT_MON_004` |
-| UNS-010 | SYS-006, SYS-011 | SWR-PAT-004 | `patient.c` : `patient_current_status()` | `PatientStatus.*` (4 tests) | `REQ_INT_MON_002`, `REQ_INT_MON_003`, `REQ_INT_ESC_001`–`REQ_INT_ESC_005` |
+| UNS-010 | SYS-006, SYS-011 | SWR-PAT-004 | `patient.c` : `patient_current_status()` | `PatientStatus.*` (4 tests) | `REQ_INT_MON_002`, `REQ_INT_MON_003`, `REQ_INT_ESC_001`â€“`REQ_INT_ESC_005` |
 | UNS-011 | SYS-010 | SWR-PAT-005 | `patient.c` : `patient_is_full()` | `PatientIsFull.*` (2 tests) | `REQ_INT_MON_005` |
-| UNS-010, UNS-017 | SYS-011, SYS-021 | SWR-PAT-006 | `patient.c` : `patient_print_summary()` | `PatientPrintSummary.*` (5 tests) | — |
+| UNS-010, UNS-017 | SYS-011, SYS-021 | SWR-PAT-006 | `patient.c` : `patient_print_summary()` | `PatientPrintSummary.*` (5 tests) | â€” |
 | UNS-017 | SYS-020, SYS-012 | SWR-PAT-007 | `patient.c` : `patient_add_reading()`, alert-event helpers | `PatientAlertEvents.REQ_PAT_007_*` (6 tests) | `REQ_INT_MON_007`, `REQ_INT_ESC_006` |
-| UNS-017 | SYS-020, SYS-021 | SWR-PAT-008 | `patient.c` : `patient_init()`, `patient_alert_event_count()`, `patient_alert_event_at()`, `patient_note_session_reset()`, `patient_session_reset_notice()` | `PatientAlertEvents.REQ_PAT_008_*` (2 tests) | — |
-| UNS-013 | SYS-013 | SWR-GUI-001 | `gui_auth.c` : `auth_validate()` | `UsersTest.REQ_GUI_001_*` (10 tests) | — |
-| UNS-013 | SYS-013 | SWR-GUI-002 | `gui_main.c` : `attempt_login()`, `login_proc()`, logout handler | `UsersTest.REQ_GUI_002_*` (5 tests) | — |
-| UNS-014, UNS-005, UNS-006 | SYS-014 | SWR-GUI-003 | `gui_main.c` : `paint_tile()`, `paint_tiles()`, `paint_status_banner()`, `update_dashboard()` | GUI demo | — |
-| UNS-014, UNS-008, UNS-009 | SYS-014 | SWR-GUI-004 | `gui_main.c` : `create_dash_controls()`, `do_admit()`, `do_add_reading()`, `do_scenario()` | GUI demo | — |
-| UNS-015 | SYS-015 | SWR-GUI-005 | `hw_vitals.h` (interface); `gui_main.c` uses only HAL calls | Architecture review | — |
-| UNS-015 | SYS-015, SYS-012 | SWR-GUI-006 | `sim_vitals.c` : `hw_init()`, `hw_get_next_reading()` | GUI demo (tiles cycle NORMAL→WARNING→CRITICAL→NORMAL) | — |
-| UNS-016 | SYS-016 | SWR-SEC-001 | `gui_users.c` : `users_init()`, `users_authenticate()`, `users_save()` | `UsersTest.REQ_SEC_001_*` (6 tests) | — |
-| UNS-016 | SYS-016 | SWR-SEC-002 | `gui_users.c` : `users_authenticate()` NULL guard on `role_out` | `UsersTest.REQ_SEC_002_RoleOutNullDoesNotCrash` (1 test) | — |
-| UNS-016 | SYS-017 | SWR-SEC-003 | `gui_users.c` : `users_change_password()`, `users_admin_set_password()` | `UsersTest.REQ_SEC_003_*` (8 tests) | — |
-| UNS-016 | SYS-017 | SWR-SEC-004 | `src/pw_hash.c` : `pw_hash()`; `gui_users.c` : all credential paths | `UsersTest.REQ_SEC_004_*` (3 tests) | — |
-| UNS-016 | SYS-016 | SWR-GUI-007 | `gui_users.c` : `users_add()`, `users_remove()`, `users_count()`, `users_get_by_index()` | `UsersTest.REQ_GUI_007_*` (8 tests) | — |
-| UNS-016 | SYS-017 | SWR-GUI-008 | `gui_main.c` : role-conditional `WM_CREATE`, `draw_pill()`, `IDC_BTN_SETTINGS`, `IDC_BTN_ACCOUNT` | GUI demo (Admin→Settings, Clinical→My Account) | — |
-| UNS-016 | SYS-016, SYS-017 | SWR-GUI-009 | `gui_main.c` : `settings_proc()`, `pwddlg_proc()`, `adduser_proc()` | GUI demo (Settings panel Add/Remove/Set Password) | — |
-| UNS-017, UNS-014 | SYS-021, SYS-014 | SWR-GUI-013 | `gui_main.c` : `create_dash_controls()`, `reposition_dash_controls()`, `update_dashboard()`; `localization.c` : session event label string | Manual GUI review (`GUI-MAN-06`) | — |
+| UNS-017 | SYS-020, SYS-021 | SWR-PAT-008 | `patient.c` : `patient_init()`, `patient_alert_event_count()`, `patient_alert_event_at()`, `patient_note_session_reset()`, `patient_session_reset_notice()` | `PatientAlertEvents.REQ_PAT_008_*` (2 tests) | â€” |
+| UNS-013 | SYS-013 | SWR-GUI-001 | `gui_auth.c` : `auth_validate()` | `UsersTest.REQ_GUI_001_*` (10 tests) | â€” |
+| UNS-013 | SYS-013 | SWR-GUI-002 | `gui_main.c` : `attempt_login()`, `login_proc()`, logout handler | `UsersTest.REQ_GUI_002_*` (5 tests) | â€” |
+| UNS-014, UNS-005, UNS-006 | SYS-014 | SWR-GUI-003 | `gui_main.c` : `paint_tile()`, `paint_tiles()`, `paint_status_banner()`, `update_dashboard()` | GUI demo | â€” |
+| UNS-014, UNS-008, UNS-009 | SYS-014 | SWR-GUI-004 | `gui_main.c` : `create_dash_controls()`, `do_admit()`, `do_add_reading()`, `do_scenario()` | GUI demo | â€” |
+| UNS-015 | SYS-015 | SWR-GUI-005 | `hw_vitals.h` (interface); `gui_main.c` uses only HAL calls | Architecture review | â€” |
+| UNS-015 | SYS-015, SYS-012 | SWR-GUI-006 | `sim_vitals.c` : `hw_init()`, `hw_get_next_reading()` | GUI demo (tiles cycle NORMALâ†’WARNINGâ†’CRITICALâ†’NORMAL) | â€” |
+| UNS-016 | SYS-016 | SWR-SEC-001 | `gui_users.c` : `users_init()`, `users_authenticate()`, `users_save()` | `UsersTest.REQ_SEC_001_*` (6 tests) | â€” |
+| UNS-016 | SYS-016 | SWR-SEC-002 | `gui_users.c` : `users_authenticate()` NULL guard on `role_out` | `UsersTest.REQ_SEC_002_RoleOutNullDoesNotCrash` (1 test) | â€” |
+| UNS-016 | SYS-017 | SWR-SEC-003 | `gui_users.c` : `users_change_password()`, `users_admin_set_password()` | `UsersTest.REQ_SEC_003_*` (8 tests) | â€” |
+| UNS-016 | SYS-017 | SWR-SEC-004 | `src/pw_hash.c` : `pw_hash()`; `gui_users.c` : all credential paths | `UsersTest.REQ_SEC_004_*` (3 tests) | â€” |
+| UNS-016 | SYS-016 | SWR-GUI-007 | `gui_users.c` : `users_add()`, `users_remove()`, `users_count()`, `users_get_by_index()` | `UsersTest.REQ_GUI_007_*` (8 tests) | â€” |
+| UNS-016 | SYS-017 | SWR-GUI-008 | `gui_main.c` : role-conditional `WM_CREATE`, `draw_pill()`, `IDC_BTN_SETTINGS`, `IDC_BTN_ACCOUNT` | GUI demo (Adminâ†’Settings, Clinicalâ†’My Account) | â€” |
+| UNS-016 | SYS-016, SYS-017 | SWR-GUI-009 | `gui_main.c` : `settings_proc()`, `pwddlg_proc()`, `adduser_proc()` | GUI demo (Settings panel Add/Remove/Set Password) | â€” |
+| UNS-017, UNS-014 | SYS-021, SYS-014 | SWR-GUI-013 | `gui_main.c` : `create_dash_controls()`, `reposition_dash_controls()`, `update_dashboard()`; `localization.c` : session event label string | Manual GUI review (`GUI-MAN-06`) | â€” |
 
 ---
 
-## Section 2 — Backward Traceability (Test → UNS)
+## Section 2 â€” Backward Traceability (Test â†’ UNS)
 
-> Reading direction: right to left — every test must justify its existence via a user need.
+> Reading direction: right to left â€” every test must justify its existence via a user need.
 
 ### Unit Tests
 
 | Test Suite | Test ID Pattern | SWR | SYS | UNS |
 |------------|-----------------|-----|-----|-----|
+| `ConfigTest` | `ConfigTest.*` | SWR-GUI-014 | SYS-022 | UNS-013, UNS-016 |
 | `HeartRate` | `REQ_VIT_001_*` | SWR-VIT-001 | SYS-001 | UNS-001, UNS-005, UNS-006 |
 | `BloodPressure` | `REQ_VIT_002_*` | SWR-VIT-002 | SYS-002 | UNS-002, UNS-005, UNS-006 |
 | `Temperature` | `REQ_VIT_003_*` | SWR-VIT-003 | SYS-003 | UNS-003, UNS-005, UNS-006 |
@@ -112,6 +116,7 @@ implementation and test coverage, and every UNS must reach at least one SWR.
 | `UsersTest` | `REQ_SEC_003_*` | SWR-SEC-003 | SYS-017 | UNS-016 |
 | `UsersTest` | `REQ_SEC_004_*` | SWR-SEC-004 | SYS-017 | UNS-016 |
 | `UsersTest` | `REQ_GUI_007_*` | SWR-GUI-007 | SYS-016 | UNS-016 |
+| `SessionTimeout` | `SessionTimeout*.*` | SWR-SEC-005 | SYS-022 | UNS-013, UNS-016 |
 | `LocalizationTest` | `LocalizationTest.*` | SWR-GUI-012 | SYS-014 | UNS-014 |
 | `RespRate` | `REQ_VIT_008_*` | SWR-VIT-008 | SYS-018 | UNS-005, UNS-006, UNS-014, UNS-015 |
 | `News2HR`, `News2RR`, etc. | `News2*.*` | SWR-NEW-001 | SYS-019 | UNS-005, UNS-006, UNS-010, UNS-014 |
@@ -120,7 +125,7 @@ implementation and test coverage, and every UNS must reach at least one SWR.
 
 Supporting implementation checks:
 - `HALTest`, `HALTestNoInit`, and `SimSequenceTest` exercise HAL safety and simulator sequencing, but approved verification for `SWR-GUI-005` and `SWR-GUI-006` remains architecture review / GUI demonstration.
-- `ConfigTest.*` exercises configuration persistence, but approved verification for `SWR-GUI-010` remains manual GUI review of the mode-toggle behavior.
+- `ConfigTest.*` directly verifies `SWR-GUI-014` idle-timeout persistence and also provides supporting persistence evidence for `SWR-GUI-010`.
 
 ### Integration Tests
 
@@ -135,101 +140,103 @@ Supporting implementation checks:
 | `PatientMonitoring` | `REQ_INT_MON_007` | SWR-PAT-007, SWR-ALT-002 | SYS-020, SYS-021 | UNS-017, UNS-010 |
 | `AlertEscalation` | `REQ_INT_ESC_001` | SWR-VIT-004, SWR-PAT-004 | SYS-004, SYS-006 | UNS-004, UNS-005, UNS-006 |
 | `AlertEscalation` | `REQ_INT_ESC_002` | SWR-VIT-001, SWR-ALT-001 | SYS-001, SYS-005 | UNS-001, UNS-005, UNS-006 |
-| `AlertEscalation` | `REQ_INT_ESC_003` | SWR-VIT-001–004, SWR-ALT-001 | SYS-001–005 | UNS-001–006 |
+| `AlertEscalation` | `REQ_INT_ESC_003` | SWR-VIT-001â€“004, SWR-ALT-001 | SYS-001â€“005 | UNS-001â€“006 |
 | `AlertEscalation` | `REQ_INT_ESC_004` | SWR-PAT-004, SWR-ALT-002 | SYS-005, SYS-006 | UNS-005, UNS-006 |
 | `AlertEscalation` | `REQ_INT_ESC_005` | SWR-VIT-001, SWR-VIT-004, SWR-PAT-004 | SYS-001, SYS-004, SYS-006 | UNS-001, UNS-004, UNS-005, UNS-006 |
 | `AlertEscalation` | `REQ_INT_ESC_006` | SWR-PAT-007, SWR-ALT-001 | SYS-020, SYS-005 | UNS-017, UNS-005, UNS-006 |
 
 ---
 
-## Section 3 — UNS Coverage Summary
+## Section 3 â€” UNS Coverage Summary
 
-> Every User Need must be covered. Any row marked ✗ is a compliance gap.
+> Every User Need must be covered. Any row marked âœ— is a compliance gap.
 
 | UNS ID | User Need (short) | SYS IDs | SWR IDs | Covered? |
 |--------|-------------------|---------|---------|----------|
-| UNS-001 | Heart rate monitoring | SYS-001 | SWR-VIT-001 | ✓ |
-| UNS-002 | Blood pressure monitoring | SYS-002 | SWR-VIT-002 | ✓ |
-| UNS-003 | Temperature monitoring | SYS-003 | SWR-VIT-003 | ✓ |
-| UNS-004 | SpO2 monitoring | SYS-004 | SWR-VIT-004 | ✓ |
-| UNS-005 | Automatic alerting | SYS-005, SYS-006, SYS-018, SYS-019 | SWR-VIT-005, SWR-VIT-007, SWR-VIT-008, SWR-NEW-001, SWR-ALT-001, SWR-ALT-002 | ✓ |
-| UNS-006 | Alert severity differentiation | SYS-005, SYS-006, SYS-018, SYS-019 | SWR-VIT-005, SWR-VIT-007, SWR-VIT-008, SWR-NEW-001, SWR-ALT-001, SWR-ALT-004 | ✓ |
-| UNS-007 | BMI display | SYS-007 | SWR-VIT-006 | ✓ |
-| UNS-008 | Patient identification | SYS-008 | SWR-PAT-001 | ✓ |
-| UNS-009 | Vital sign history | SYS-009 | SWR-PAT-002, SWR-PAT-003 | ✓ |
-| UNS-010 | Consolidated summary | SYS-011, SYS-019, SYS-021 | SWR-PAT-004, SWR-PAT-006, SWR-VIT-007, SWR-NEW-001 | ✓ |
-| UNS-011 | Data integrity | SYS-010, SYS-012 | SWR-PAT-002, SWR-PAT-005, SWR-ALT-003, SWR-PAT-001 | ✓ |
-| UNS-012 | Platform compatibility | SYS-012 | SWR-PAT-001, SWR-ALT-003 | ✓ |
-| UNS-013 | User authentication | SYS-013 | SWR-GUI-001, SWR-GUI-002 | ✓ |
-| UNS-014 | Graphical dashboard | SYS-014, SYS-018, SYS-019, SYS-021 | SWR-GUI-003, SWR-GUI-004, SWR-GUI-012, SWR-GUI-013, SWR-VIT-008, SWR-NEW-001 | ✓ |
-| UNS-015 | Live monitoring feed | SYS-015, SYS-018 | SWR-GUI-005, SWR-GUI-006, SWR-GUI-010, SWR-GUI-011, SWR-VIT-008 | ✓ |
-| UNS-016 | Role-based access / multi-user | SYS-016, SYS-017 | SWR-SEC-001, SWR-SEC-002, SWR-SEC-003, SWR-GUI-007, SWR-GUI-008, SWR-GUI-009 | ✓ |
-| UNS-017 | Session alarm event review | SYS-020, SYS-021 | SWR-PAT-006, SWR-PAT-007, SWR-PAT-008, SWR-GUI-013 | ✓ |
+| UNS-001 | Heart rate monitoring | SYS-001 | SWR-VIT-001 | âœ“ |
+| UNS-002 | Blood pressure monitoring | SYS-002 | SWR-VIT-002 | âœ“ |
+| UNS-003 | Temperature monitoring | SYS-003 | SWR-VIT-003 | âœ“ |
+| UNS-004 | SpO2 monitoring | SYS-004 | SWR-VIT-004 | âœ“ |
+| UNS-005 | Automatic alerting | SYS-005, SYS-006, SYS-018, SYS-019 | SWR-VIT-005, SWR-VIT-007, SWR-VIT-008, SWR-NEW-001, SWR-ALT-001, SWR-ALT-002 | âœ“ |
+| UNS-006 | Alert severity differentiation | SYS-005, SYS-006, SYS-018, SYS-019 | SWR-VIT-005, SWR-VIT-007, SWR-VIT-008, SWR-NEW-001, SWR-ALT-001, SWR-ALT-004 | âœ“ |
+| UNS-007 | BMI display | SYS-007 | SWR-VIT-006 | âœ“ |
+| UNS-008 | Patient identification | SYS-008 | SWR-PAT-001 | âœ“ |
+| UNS-009 | Vital sign history | SYS-009 | SWR-PAT-002, SWR-PAT-003 | âœ“ |
+| UNS-010 | Consolidated summary | SYS-011, SYS-019, SYS-021 | SWR-PAT-004, SWR-PAT-006, SWR-VIT-007, SWR-NEW-001 | âœ“ |
+| UNS-011 | Data integrity | SYS-010, SYS-012 | SWR-PAT-002, SWR-PAT-005, SWR-ALT-003, SWR-PAT-001 | âœ“ |
+| UNS-012 | Platform compatibility | SYS-012 | SWR-PAT-001, SWR-ALT-003 | âœ“ |
+| UNS-013 | User authentication | SYS-013, SYS-022 | SWR-GUI-001, SWR-GUI-002, SWR-GUI-014, SWR-SEC-005 | âœ“ |
+| UNS-014 | Graphical dashboard | SYS-014, SYS-018, SYS-019, SYS-021 | SWR-GUI-003, SWR-GUI-004, SWR-GUI-012, SWR-GUI-013, SWR-VIT-008, SWR-NEW-001 | âœ“ |
+| UNS-015 | Live monitoring feed | SYS-015, SYS-018 | SWR-GUI-005, SWR-GUI-006, SWR-GUI-010, SWR-GUI-011, SWR-VIT-008 | âœ“ |
+| UNS-016 | Role-based access / multi-user | SYS-016, SYS-017, SYS-022 | SWR-SEC-001, SWR-SEC-002, SWR-SEC-003, SWR-GUI-007, SWR-GUI-008, SWR-GUI-009, SWR-GUI-014, SWR-SEC-005 | âœ“ |
+| UNS-017 | Session alarm event review | SYS-020, SYS-021 | SWR-PAT-006, SWR-PAT-007, SWR-PAT-008, SWR-GUI-013 | âœ“ |
 
-**Result: 17 / 17 User Needs covered ✓**
+**Result: 17 / 17 User Needs covered âœ“**
 
 ---
 
-## Section 4 — SWR Coverage Summary
+## Section 4 â€” SWR Coverage Summary
 
 > Every SWR must have implementation and at least one test. Any gap is a finding.
 
 | SWR ID | Implementation | Unit Tests | Integration Tests | Covered? |
 |--------|----------------|------------|-------------------|----------|
-| SWR-VIT-001 | `check_heart_rate()` | 14 | 2 | ✓ |
-| SWR-VIT-002 | `check_blood_pressure()` | 12 | 1 | ✓ |
-| SWR-VIT-003 | `check_temperature()` | 10 | 2 | ✓ |
-| SWR-VIT-004 | `check_spo2()` | 8 | 2 | ✓ |
-| SWR-VIT-005 | `overall_alert_level()` | 8 | 5 | ✓ |
-| SWR-VIT-006 | `calculate_bmi()`, `bmi_category()` | 12 | 1 | ✓ |
-| SWR-VIT-007 | `alert_level_str()` | 4 | all | ✓ |
-| SWR-ALT-001 | `generate_alerts()` | 4 | 3 | ✓ |
-| SWR-ALT-002 | `generate_alerts()` | 1 | 1 | ✓ |
-| SWR-ALT-003 | `generate_alerts()` | 2 | — | ✓ |
-| SWR-ALT-004 | `generate_alerts()` | 2 | — | ✓ |
-| SWR-PAT-001 | `patient_init()` | 3 | 2 | ✓ |
-| SWR-PAT-002 | `patient_add_reading()` | 5 | 3 | ✓ |
-| SWR-PAT-003 | `patient_latest_reading()` | 2 | 1 | ✓ |
-| SWR-PAT-004 | `patient_current_status()` | 4 | 7 | ✓ |
-| SWR-PAT-005 | `patient_is_full()` | 2 | 1 | ✓ |
-| SWR-PAT-006 | `patient_print_summary()` | 5 | — | ✓ |
-| SWR-PAT-007 | `patient_add_reading()`, alert-event helpers | 6 | 2 | ✓ |
-| SWR-PAT-008 | `patient_init()`, `patient_alert_event_count()`, `patient_alert_event_at()`, `patient_note_session_reset()`, `patient_session_reset_notice()` | 2 | — | ✓ |
-| SWR-GUI-001 | `auth_validate()` | 10 | — | ✓ |
-| SWR-GUI-002 | `attempt_login()`, `login_proc()`, logout | 5 | — | ✓ |
-| SWR-GUI-003 | `paint_tile()`, `paint_tiles()`, `paint_status_banner()` | GUI demo | — | ✓ |
-| SWR-GUI-004 | `create_dash_controls()`, `do_admit()`, `do_add_reading()` | GUI demo | — | ✓ |
-| SWR-GUI-005 | `hw_vitals.h` HAL interface | Architecture review | — | ✓ |
-| SWR-GUI-006 | `sim_vitals.c` : `hw_init()`, `hw_get_next_reading()` | GUI demo | — | ✓ |
-| SWR-SEC-001 | `users_init()`, `users_authenticate()`, `users_save()` | 6 | — | ✓ |
-| SWR-SEC-002 | `users_authenticate()` NULL guard | 1 | — | ✓ |
-| SWR-SEC-003 | `users_change_password()`, `users_admin_set_password()` | 8 | — | ✓ |
-| SWR-SEC-004 | `pw_hash()` + all credential paths in `gui_users.c` | 3 | — | ✓ |
-| SWR-GUI-007 | `users_add()`, `users_remove()`, `users_count()`, `users_get_by_index()` | 8 | — | ✓ |
-| SWR-GUI-008 | Role-conditional `WM_CREATE`, `draw_pill()`, `IDC_BTN_SETTINGS` | GUI demo | — | ✓ |
-| SWR-GUI-009 | `settings_proc()`, `pwddlg_proc()`, `adduser_proc()` | GUI demo | — | ✓ |
-| SWR-GUI-010 | `gui_main.c`, `app_config.c` : mode toggle + persistence | Manual GUI review + `ConfigTest.*` support (10) | — | ✓ |
-| SWR-GUI-011 | `gui_main.c` : `paint_status_banner()`, scroll offset | Manual visual review | — | ✓ |
-| SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : selector strings, persistence/load | `LocalizationTest.*` (8) + supplemental `DVT-GUI-16` | — | ✓ |
-| SWR-GUI-013 | `create_dash_controls()`, `reposition_dash_controls()`, `update_dashboard()` | Manual GUI review (`GUI-MAN-06`) | — | ✓ |
-| SWR-VIT-008 | `vitals.c` : `check_respiration_rate()` | 15 | — | ✓ |
-| SWR-NEW-001 | `news2.c` : `news2_calculate()` | 53 | — | ✓ |
-| SWR-ALM-001 | `alarm_limits.c` : `alarm_limits_defaults()`, `alarm_check_*()` | 31 | — | ✓ |
-| SWR-TRD-001 | `trend.c` : `trend_direction()`, `trend_extract_*()` | 18 | — | ✓ |
+| SWR-VIT-001 | `check_heart_rate()` | 14 | 2 | âœ“ |
+| SWR-VIT-002 | `check_blood_pressure()` | 12 | 1 | âœ“ |
+| SWR-VIT-003 | `check_temperature()` | 10 | 2 | âœ“ |
+| SWR-VIT-004 | `check_spo2()` | 8 | 2 | âœ“ |
+| SWR-VIT-005 | `overall_alert_level()` | 8 | 5 | âœ“ |
+| SWR-VIT-006 | `calculate_bmi()`, `bmi_category()` | 12 | 1 | âœ“ |
+| SWR-VIT-007 | `alert_level_str()` | 4 | all | âœ“ |
+| SWR-ALT-001 | `generate_alerts()` | 4 | 3 | âœ“ |
+| SWR-ALT-002 | `generate_alerts()` | 1 | 1 | âœ“ |
+| SWR-ALT-003 | `generate_alerts()` | 2 | â€” | âœ“ |
+| SWR-ALT-004 | `generate_alerts()` | 2 | â€” | âœ“ |
+| SWR-PAT-001 | `patient_init()` | 3 | 2 | âœ“ |
+| SWR-PAT-002 | `patient_add_reading()` | 5 | 3 | âœ“ |
+| SWR-PAT-003 | `patient_latest_reading()` | 2 | 1 | âœ“ |
+| SWR-PAT-004 | `patient_current_status()` | 4 | 7 | âœ“ |
+| SWR-PAT-005 | `patient_is_full()` | 2 | 1 | âœ“ |
+| SWR-PAT-006 | `patient_print_summary()` | 5 | â€” | âœ“ |
+| SWR-PAT-007 | `patient_add_reading()`, alert-event helpers | 6 | 2 | âœ“ |
+| SWR-PAT-008 | `patient_init()`, `patient_alert_event_count()`, `patient_alert_event_at()`, `patient_note_session_reset()`, `patient_session_reset_notice()` | 2 | â€” | âœ“ |
+| SWR-GUI-001 | `auth_validate()` | 10 | â€” | âœ“ |
+| SWR-GUI-002 | `attempt_login()`, `login_proc()`, logout | 5 | â€” | âœ“ |
+| SWR-GUI-003 | `paint_tile()`, `paint_tiles()`, `paint_status_banner()` | GUI demo | â€” | âœ“ |
+| SWR-GUI-004 | `create_dash_controls()`, `do_admit()`, `do_add_reading()` | GUI demo | â€” | âœ“ |
+| SWR-GUI-005 | `hw_vitals.h` HAL interface | Architecture review | â€” | âœ“ |
+| SWR-GUI-006 | `sim_vitals.c` : `hw_init()`, `hw_get_next_reading()` | GUI demo | â€” | âœ“ |
+| SWR-SEC-001 | `users_init()`, `users_authenticate()`, `users_save()` | 6 | â€” | âœ“ |
+| SWR-SEC-002 | `users_authenticate()` NULL guard | 1 | â€” | âœ“ |
+| SWR-SEC-003 | `users_change_password()`, `users_admin_set_password()` | 8 | â€” | âœ“ |
+| SWR-SEC-004 | `pw_hash()` + all credential paths in `gui_users.c` | 3 | â€” | âœ“ |
+| SWR-SEC-005 | `session_timeout.c`, `gui_main.c` : idle policy + lock/unlock flow | `SessionTimeout*.*` (7) + manual GUI review (`GUI-MAN-07`) | â€” | âœ“ |
+| SWR-GUI-007 | `users_add()`, `users_remove()`, `users_count()`, `users_get_by_index()` | 8 | â€” | âœ“ |
+| SWR-GUI-008 | Role-conditional `WM_CREATE`, `draw_pill()`, `IDC_BTN_SETTINGS` | GUI demo | â€” | âœ“ |
+| SWR-GUI-009 | `settings_proc()`, `pwddlg_proc()`, `adduser_proc()` | GUI demo | â€” | âœ“ |
+| SWR-GUI-010 | `gui_main.c`, `app_config.c` : mode toggle + persistence | Manual GUI review + `ConfigTest.*` support (10) | â€” | âœ“ |
+| SWR-GUI-011 | `gui_main.c` : `paint_status_banner()`, scroll offset | Manual visual review | â€” | âœ“ |
+| SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : selector strings, persistence/load | `LocalizationTest.*` (8) + supplemental `DVT-GUI-16` | â€” | âœ“ |
+| SWR-GUI-013 | `create_dash_controls()`, `reposition_dash_controls()`, `update_dashboard()` | Manual GUI review (`GUI-MAN-06`) | â€” | âœ“ |
+| SWR-GUI-014 | `gui_main.c`, `app_config.c` : Session tab + idle-timeout persistence | `ConfigTest.*` (17) + manual GUI review (`GUI-MAN-07`) | â€” | âœ“ |
+| SWR-VIT-008 | `vitals.c` : `check_respiration_rate()` | 15 | â€” | âœ“ |
+| SWR-NEW-001 | `news2.c` : `news2_calculate()` | 53 | â€” | âœ“ |
+| SWR-ALM-001 | `alarm_limits.c` : `alarm_limits_defaults()`, `alarm_check_*()` | 31 | â€” | âœ“ |
+| SWR-TRD-001 | `trend.c` : `trend_direction()`, `trend_extract_*()` | 18 | â€” | âœ“ |
 
-**Result: 40 / 40 SWRs implemented and tested ✓**
+**Result: 42 / 42 SWRs implemented and tested âœ“**
 
 ---
 
-## Section 5 — Code Coverage Summary
+## Section 5 â€” Code Coverage Summary
 
-**Standard:** IEC 62304 Class B — Statement + Branch Coverage Target: 100%
+**Standard:** IEC 62304 Class B â€” Statement + Branch Coverage Target: 100%
 
 | Source File | Lines | Covered | % | Branches | Covered | % | Notes |
 |-------------|-------|---------|---|----------|---------|---|-------|
 | `src/vitals.c` | 143 | 143 | 100% | 52 | 52 | 100% | `REQ_VIT_007_Unknown` test covers `default:` branch in `alert_level_str()` |
-| `src/alerts.c` | 48 | 48 | 100% | 18 | 18 | 100% | — |
-| `src/patient.c` | 61 | 61 | 100% | 14 | 14 | 100% | — |
+| `src/alerts.c` | 48 | 48 | 100% | 18 | 18 | 100% | â€” |
+| `src/patient.c` | 61 | 61 | 100% | 14 | 14 | 100% | â€” |
 | `src/gui_auth.c` | 28 | 28 | 100% | 6 | 6 | 100% | Delegation layer fully covered by test_auth.cpp |
 | `src/gui_users.c` | ~120 | ~120 | 100% | ~40 | ~40 | 100% | All user management paths covered by REQ_SEC_* and REQ_GUI_007_* tests |
 | `src/news2.c` | ~90 | ~90 | 100% | ~30 | ~30 | 100% | All NEWS2 scoring paths covered by News2* tests |
@@ -237,41 +244,42 @@ Supporting implementation checks:
 | `src/trend.c` | ~60 | ~60 | 100% | ~12 | ~12 | 100% | All trend direction + extract paths covered by Trend* tests |
 | `src/pw_hash.c` | ~40 | ~40 | 100% | ~6 | ~6 | 100% | SHA-256 hashing covered by REQ_SEC_004 tests |
 
-**Coverage Rationale — `alert_level_str()` `default:` branch:**
+**Coverage Rationale â€” `alert_level_str()` `default:` branch:**
 The `default: return "UNKNOWN"` branch in `alert_level_str()` (`vitals.c`) is a
-defensive IEC 62304 guard against undefined enum casts — it is unreachable in
+defensive IEC 62304 guard against undefined enum casts â€” it is unreachable in
 normal production execution because all call sites pass only valid `AlertLevel`
 enum values. A dedicated test (`REQ_VIT_007_Unknown`) uses an explicit
 out-of-range cast `(AlertLevel)99` to exercise this path, achieving 100% branch
 coverage. This approach is accepted under IEC 62304 and is documented here as
-the formal rationale per §5.5.4 (software unit acceptance criteria).
+the formal rationale per Â§5.5.4 (software unit acceptance criteria).
 
 **GUI source files** (`gui_main.c`, `sim_vitals.c`) contain primarily Win32 API
 message-handling code (WndProc chains, GDI painting) that requires a running
 Windows message loop and is not amenable to automated unit testing without a
 full GUI test harness. These files are verified by structured GUI demonstration
-per IEC 62304 §5.6.3 (integration testing) and §5.6.7 (GUI verification).
+per IEC 62304 Â§5.6.3 (integration testing) and Â§5.6.7 (GUI verification).
 This is recorded as an accepted coverage exclusion with a documented rationale.
 
 ---
 
-## Section 6 — Test Count Summary
+## Section 6 â€” Test Count Summary
 
 | Test File | Tests | SWRs Verified |
 |-----------|-------|---------------|
-| `tests/unit/test_vitals.cpp` | 80 | SWR-VIT-001 – SWR-VIT-008 |
-| `tests/unit/test_alerts.cpp` | 11 | SWR-ALT-001 – SWR-ALT-004 |
-| `tests/unit/test_patient.cpp` | 29 | SWR-PAT-001 – SWR-PAT-008 |
-| `tests/unit/test_auth.cpp` | 41 | SWR-GUI-001, SWR-GUI-002, SWR-SEC-001–004, SWR-GUI-007 |
+| `tests/unit/test_vitals.cpp` | 80 | SWR-VIT-001 â€“ SWR-VIT-008 |
+| `tests/unit/test_alerts.cpp` | 11 | SWR-ALT-001 â€“ SWR-ALT-004 |
+| `tests/unit/test_patient.cpp` | 29 | SWR-PAT-001 â€“ SWR-PAT-008 |
+| `tests/unit/test_auth.cpp` | 41 | SWR-GUI-001, SWR-GUI-002, SWR-SEC-001â€“004, SWR-GUI-007 |
 | `tests/unit/test_news2.cpp` | 53 | SWR-NEW-001 |
 | `tests/unit/test_alarm_limits.cpp` | 31 | SWR-ALM-001 |
 | `tests/unit/test_trend.cpp` | 18 | SWR-TRD-001 |
 | `tests/unit/test_hal.cpp` | 12 | Supporting HAL / simulator checks only; no direct SWR verification claim |
-| `tests/unit/test_config.cpp` | 10 | Supporting config persistence checks only; no direct SWR verification claim |
+| `tests/unit/test_config.cpp` | 17 | SWR-GUI-014 + supporting config persistence evidence for SWR-GUI-010 |
+| `tests/unit/test_session_timeout.cpp` | 7 | SWR-SEC-005 |
 | `tests/unit/test_localization.cpp` | 8 | SWR-GUI-012 |
 | `tests/integration/test_patient_monitoring.cpp` | 7 | SWR-PAT-*, SWR-VIT-*, SWR-ALT-* |
 | `tests/integration/test_alert_escalation.cpp` | 7 | SWR-VIT-*, SWR-ALT-*, SWR-PAT-004, SWR-PAT-007 |
-| **Total** | **307** | **40 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
+| **Total** | **321** | **42 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
 
 ---
 
@@ -291,3 +299,4 @@ This is recorded as an accepted coverage exclusion with a documented rationale.
 | J   | 2026-05-05 | Codex implementer | Restored defensible SYS-level traceability for RR and NEWS2 requirements; 37/37 SWR, 295 tests |
 | K   | 2026-05-05 | Codex implementer | Added session alarm event review traceability: UNS-017, SYS-020/021, SWR-PAT-007/008, SWR-GUI-013; 40/40 SWR, 305 tests |
 | L   | 2026-05-06 | Codex implementer | Added session-reset disclosure traceability and updated automated totals to 307 tests |
+| M   | 2026-05-06 | Codex implementer | Added idle session-lock traceability: SYS-022, SWR-SEC-005, SWR-GUI-014; 42/42 SWR, 321 tests |

--- a/requirements/UNS.md
+++ b/requirements/UNS.md
@@ -1,9 +1,9 @@
 # User Needs Specification (UNS)
 
-**Document ID:** UNS-001-REV-E
+**Document ID:** UNS-001-REV-F
 **Project:** Patient Vital Signs Monitor
 **Version:** 1.0.0
-**Date:** 2026-05-05
+**Date:** 2026-05-06
 **Status:** Approved
 **Standard:** 21 CFR 820.30(c) / IEC 62304 §5.1
 
@@ -143,6 +143,8 @@ dependencies create deployment and security risks.
 ### UNS-013 — User Authentication
 **Need:** The system shall require the clinician to authenticate with a
 username and password before accessing patient data or any monitoring function.
+The system shall also protect unattended authenticated sessions by requiring
+re-authentication after a bounded period of user inactivity.
 **Rationale:** Unauthorised access to patient health data is a clinical and
 regulatory risk; access control is required under HIPAA and IEC 62304 risk
 management.
@@ -176,8 +178,8 @@ workflow and provides a plug point for real hardware integration.
 ### UNS-016 — Role-Based Access and Multi-User Support
 **Need:** Different clinical staff roles (ward administrators and bedside
 clinicians) require different levels of system access. An administrator must
-be able to manage user accounts and credentials without exposing those
-controls to clinical users.
+be able to manage user accounts, credentials, and local session-protection
+policy without exposing those controls to clinical users.
 **Rationale:** In a clinical environment, user management tasks (adding and
 removing accounts, resetting passwords) must be separated from patient
 monitoring to comply with role-based access control requirements and to
@@ -208,3 +210,4 @@ reconstruction from raw reading history.
 | C   | 2026-04-07 | vinu-engineer   | Added UNS-015 (live monitoring feed / HAL) |
 | D   | 2026-04-07 | vinu-engineer   | Added UNS-016 (role-based access / multi-user) |
 | E   | 2026-05-05 | Codex implementer | Added UNS-017 (session alarm event review) |
+| F   | 2026-05-06 | Codex implementer | Extended UNS-013 and UNS-016 for configurable idle session locking |

--- a/src/app_config.c
+++ b/src/app_config.c
@@ -5,6 +5,8 @@
  * The configuration file is a simple key=value text file:
  *
  *   sim_enabled=1
+ *   language=0
+ *   idle_timeout_minutes=5
  *
  * File location (in priority order):
  *  1. Path supplied by app_config_set_path() (non-NULL).
@@ -15,6 +17,7 @@
  */
 
 #include "app_config.h"
+#include "session_timeout.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -30,6 +33,13 @@
 
 /* When non-empty this overrides the exe-derived path (set by tests). */
 static char s_override_path[CFG_MAX_PATH] = {0};
+
+typedef struct
+{
+    int sim_enabled;
+    int language;
+    int idle_timeout_minutes;
+} AppConfigData;
 
 /* -------------------------------------------------------------------------
  * Internal helpers
@@ -80,6 +90,129 @@ static int get_cfg_path(char *buf, size_t buf_size)
 #endif
 }
 
+static void app_config_defaults(AppConfigData *cfg)
+{
+    cfg->sim_enabled = 1;
+    cfg->language = 0;
+    cfg->idle_timeout_minutes = SESSION_TIMEOUT_DEFAULT_MINUTES;
+}
+
+static int parse_named_int(const char *line, const char *key, int *value_out)
+{
+    const size_t key_len = strlen(key);
+    char trailing[2];
+    int value = 0;
+
+    if (strncmp(line, key, key_len) != 0 || line[key_len] != '=')
+        return 0;
+
+    if (sscanf(line + key_len + 1u, "%d%1s", &value, trailing) == 1)
+    {
+        *value_out = value;
+        return 1;
+    }
+
+    return -1;
+}
+
+static int app_config_read(AppConfigData *cfg,
+                           int *sim_found,
+                           int *lang_found,
+                           int *idle_timeout_found)
+{
+    char cfg_path[CFG_MAX_PATH] = {0};
+    FILE *f = NULL;
+    char line[128];
+
+    if (sim_found != NULL)
+        *sim_found = 0;
+    if (lang_found != NULL)
+        *lang_found = 0;
+    if (idle_timeout_found != NULL)
+        *idle_timeout_found = 0;
+
+    if (cfg == NULL)
+        return 0;
+
+    app_config_defaults(cfg);
+
+    if (!get_cfg_path(cfg_path, sizeof(cfg_path)))
+        return 0;
+
+    f = fopen(cfg_path, "r");
+    if (f == NULL)
+        return 0;
+
+    while (fgets(line, (int)sizeof(line), f) != NULL)
+    {
+        int value = 0;
+        int rc = parse_named_int(line, "sim_enabled", &value);
+        if (rc != 0)
+        {
+            if (rc > 0)
+            {
+                cfg->sim_enabled = (value != 0) ? 1 : 0;
+                if (sim_found != NULL)
+                    *sim_found = 1;
+            }
+            continue;
+        }
+
+        rc = parse_named_int(line, "language", &value);
+        if (rc != 0)
+        {
+            if (rc > 0)
+            {
+                cfg->language = (value >= 0 && value < 4) ? value : 0;
+                if (lang_found != NULL)
+                    *lang_found = 1;
+            }
+            continue;
+        }
+
+        rc = parse_named_int(line, "idle_timeout_minutes", &value);
+        if (rc != 0)
+        {
+            if (rc > 0)
+            {
+                cfg->idle_timeout_minutes =
+                    session_timeout_normalize_minutes(value);
+                if (idle_timeout_found != NULL &&
+                    session_timeout_is_valid_minutes(value))
+                {
+                    *idle_timeout_found = 1;
+                }
+            }
+            continue;
+        }
+    }
+
+    fclose(f);
+    return 1;
+}
+
+static int app_config_write(const AppConfigData *cfg)
+{
+    char cfg_path[CFG_MAX_PATH] = {0};
+    FILE *f = NULL;
+    int ok = 0;
+
+    if (cfg == NULL || !get_cfg_path(cfg_path, sizeof(cfg_path)))
+        return 0;
+
+    f = fopen(cfg_path, "w");
+    if (f == NULL)
+        return 0;
+
+    ok = (fprintf(f,
+                  "sim_enabled=%d\nlanguage=%d\nidle_timeout_minutes=%d\n",
+                  cfg->sim_enabled ? 1 : 0,
+                  cfg->language,
+                  session_timeout_normalize_minutes(cfg->idle_timeout_minutes)) > 0);
+    fclose(f);
+    return ok ? 1 : 0;
+}
+
 /* -------------------------------------------------------------------------
  * Public API
  * ---------------------------------------------------------------------- */
@@ -99,109 +232,56 @@ void app_config_set_path(const char *path)
 
 int app_config_load(int *sim_enabled_out)
 {
+    AppConfigData cfg;
+    int sim_found = 0;
+
     if (sim_enabled_out == NULL)
         return 0;
 
-    /* Apply default before attempting to read */
-    *sim_enabled_out = 1;
-
-    char cfg_path[CFG_MAX_PATH] = {0};
-    if (!get_cfg_path(cfg_path, sizeof(cfg_path)))
-        return 0;
-
-    FILE *f = fopen(cfg_path, "r");
-    if (f == NULL)
-        return 0; /* file absent – caller gets the default */
-
-    char line[128];
-    int parsed = 0;
-    while (fgets(line, (int)sizeof(line), f) != NULL)
-    {
-        int value = 0;
-        if (sscanf(line, "sim_enabled=%d", &value) == 1)
-        {
-            *sim_enabled_out = (value != 0) ? 1 : 0;
-            parsed = 1;
-            break;
-        }
-    }
-
-    fclose(f);
-
-    if (!parsed)
-    {
-        /* File exists but does not contain a recognisable value */
-        *sim_enabled_out = 1;
-        return 0;
-    }
-
-    return 1;
+    (void)app_config_read(&cfg, &sim_found, NULL, NULL);
+    *sim_enabled_out = cfg.sim_enabled;
+    return sim_found ? 1 : 0;
 }
 
 int app_config_save(int sim_enabled)
 {
-    /* Preserve language setting when saving sim_enabled */
-    int lang = app_config_load_language();
+    AppConfigData cfg;
 
-    char cfg_path[CFG_MAX_PATH] = {0};
-    if (!get_cfg_path(cfg_path, sizeof(cfg_path)))
-        return 0;
-
-    FILE *f = fopen(cfg_path, "w");
-    if (f == NULL)
-        return 0;
-
-    int ok = (fprintf(f, "sim_enabled=%d\nlanguage=%d\n",
-                       sim_enabled ? 1 : 0, lang) > 0);
-    fclose(f);
-    return ok ? 1 : 0;
+    (void)app_config_read(&cfg, NULL, NULL, NULL);
+    cfg.sim_enabled = sim_enabled ? 1 : 0;
+    return app_config_write(&cfg);
 }
 
 int app_config_load_language(void)
 {
-    char cfg_path[CFG_MAX_PATH] = {0};
-    if (!get_cfg_path(cfg_path, sizeof(cfg_path)))
-        return 0;
+    AppConfigData cfg;
 
-    FILE *f = fopen(cfg_path, "r");
-    if (f == NULL)
-        return 0;
-
-    char line[128];
-    int lang = 0;
-    while (fgets(line, (int)sizeof(line), f) != NULL)
-    {
-        int value = 0;
-        if (sscanf(line, "language=%d", &value) == 1)
-        {
-            if (value >= 0 && value < 4)
-                lang = value;
-            break;
-        }
-    }
-    fclose(f);
-    return lang;
+    (void)app_config_read(&cfg, NULL, NULL, NULL);
+    return cfg.language;
 }
 
 int app_config_save_language(int language)
 {
-    /* Preserve sim_enabled setting when saving language */
-    int sim = 1;
-    app_config_load(&sim);
+    AppConfigData cfg;
 
-    if (language < 0 || language > 3)
-        language = 0;
+    (void)app_config_read(&cfg, NULL, NULL, NULL);
+    cfg.language = (language >= 0 && language < 4) ? language : 0;
+    return app_config_write(&cfg);
+}
 
-    char cfg_path[CFG_MAX_PATH] = {0};
-    if (!get_cfg_path(cfg_path, sizeof(cfg_path)))
-        return 0;
+int app_config_load_idle_timeout_minutes(void)
+{
+    AppConfigData cfg;
 
-    FILE *f = fopen(cfg_path, "w");
-    if (f == NULL)
-        return 0;
+    (void)app_config_read(&cfg, NULL, NULL, NULL);
+    return cfg.idle_timeout_minutes;
+}
 
-    int ok = (fprintf(f, "sim_enabled=%d\nlanguage=%d\n",
-                       sim, language) > 0);
-    fclose(f);
-    return ok ? 1 : 0;
+int app_config_save_idle_timeout_minutes(int minutes)
+{
+    AppConfigData cfg;
+
+    (void)app_config_read(&cfg, NULL, NULL, NULL);
+    cfg.idle_timeout_minutes = session_timeout_normalize_minutes(minutes);
+    return app_config_write(&cfg);
 }

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -38,6 +38,7 @@
 #include "hw_vitals.h"
 #include "app_config.h"
 #include "localization.h"
+#include "session_timeout.h"
 
 /* ===================================================================
  * App metadata
@@ -54,6 +55,7 @@
 #define CLASS_SETTINGS "PVM_Settings"
 #define CLASS_PWDDLG   "PVM_PwdDlg"
 #define CLASS_ADDUSER  "PVM_AddUser"
+#define CLASS_LOCK     "PVM_Lock"
 
 /* ===================================================================
  * Control IDs — Login
@@ -99,6 +101,7 @@
 #define IDC_LIST_HISTORY 1301
 #define IDC_LIST_EVENTS  1302
 #define TIMER_SIM        1
+#define TIMER_IDLE       2
 
 /* ===================================================================
  * Control IDs — Settings window
@@ -116,6 +119,8 @@
 /* Simulation tab in Settings @req SWR-GUI-010 */
 #define IDC_BTN_SIM_TOGGLE 1225
 #define IDC_STC_SIM_STATUS 1226
+#define IDC_EDT_IDLE_TIMEOUT 1237
+#define IDC_BTN_IDLE_APPLY 1238
 
 /* ===================================================================
  * Control IDs — Password change dialog
@@ -126,6 +131,11 @@
 #define IDC_BTN_PWOK      1243
 #define IDC_BTN_PWCANCEL  1244
 #define IDC_STC_PWERR     1245
+#define IDC_LCK_USER      1250
+#define IDC_LCK_PASS      1251
+#define IDC_LCK_BTN_UNLOCK 1252
+#define IDC_LCK_BTN_LOGOUT 1253
+#define IDC_LCK_ERR       1254
 
 /* ===================================================================
  * Control IDs — Alarm Limits tab (Settings)  @req SWR-ALM-001
@@ -197,6 +207,7 @@ typedef struct {
     HWND      hwnd_settings;
     HWND      hwnd_pwddlg;
     HWND      hwnd_adduser;
+    HWND      hwnd_lock;
 
     char     logged_user[USERS_MAX_USERNAME_LEN];     /* display name for UI */
     char     logged_username[USERS_MAX_USERNAME_LEN]; /* actual username for auth */
@@ -206,8 +217,12 @@ typedef struct {
     int           has_patient;
     int           sim_paused;
     int           sim_enabled;  /**< 1=simulation mode, 0=device/HAL mode @req SWR-GUI-010 */
+    int           idle_timeout_minutes;
+    int           session_locked;
+    int           reopen_settings_after_unlock;
     int           sim_msg_scroll_offset; /**< Offset for rolling message in simulation mode */
     AlarmLimits   alarm_limits; /**< Configurable per-parameter alarm limits @req SWR-ALM-001 */
+    DWORD         last_activity_tick;
 
     HFONT font_hdr;
     HFONT font_tile_val;
@@ -233,6 +248,7 @@ static LRESULT CALLBACK dash_proc    (HWND, UINT, WPARAM, LPARAM);
 static LRESULT CALLBACK settings_proc(HWND, UINT, WPARAM, LPARAM);
 static LRESULT CALLBACK pwddlg_proc  (HWND, UINT, WPARAM, LPARAM);
 static LRESULT CALLBACK adduser_proc (HWND, UINT, WPARAM, LPARAM);
+static LRESULT CALLBACK lock_proc    (HWND, UINT, WPARAM, LPARAM);
 static void create_dashboard(void);
 static void update_dashboard(HWND w);
 static void refresh_dash_language(HWND w);
@@ -240,6 +256,8 @@ static void apply_sim_mode(HWND dash);
 static void open_settings(HWND parent);
 static void open_pwddlg(HWND parent, const char *user, int admin_mode);
 static void open_adduser(HWND parent);
+static void session_note_activity(void);
+static void logout_authenticated_session(void);
 
 /* ===================================================================
  * GDI helpers
@@ -610,6 +628,163 @@ static int get_txt(HWND p, int id, char *out, int len)
 }
 static void set_txt(HWND p, int id, const char *s) { SetWindowTextA(GetDlgItem(p,id),s); }
 
+static void session_note_activity(void)
+{
+    if (g_app.hwnd_dash != NULL && !g_app.session_locked)
+        g_app.last_activity_tick = GetTickCount();
+}
+
+static void session_track_message(UINT msg)
+{
+    switch (msg) {
+    case WM_COMMAND:
+    case WM_NOTIFY:
+    case WM_KEYDOWN:
+    case WM_SYSKEYDOWN:
+    case WM_CHAR:
+    case WM_MOUSEMOVE:
+    case WM_MOUSEWHEEL:
+    case WM_MOUSEHWHEEL:
+    case WM_LBUTTONDOWN:
+    case WM_LBUTTONUP:
+    case WM_LBUTTONDBLCLK:
+    case WM_RBUTTONDOWN:
+    case WM_RBUTTONUP:
+    case WM_RBUTTONDBLCLK:
+    case WM_MBUTTONDOWN:
+    case WM_MBUTTONUP:
+    case WM_MBUTTONDBLCLK:
+    case WM_VSCROLL:
+    case WM_HSCROLL:
+        session_note_activity();
+        break;
+    default:
+        break;
+    }
+}
+
+static void open_login_window(void)
+{
+    if (g_app.hwnd_login != NULL)
+        return;
+
+    g_app.hwnd_login = CreateWindowExA(
+        WS_EX_APPWINDOW, CLASS_LOGIN, APP_TITLE,
+        WS_OVERLAPPED|WS_CAPTION|WS_SYSMENU,
+        CW_USEDEFAULT, CW_USEDEFAULT, 440, 520,
+        NULL, NULL, g_app.inst, NULL);
+    ShowWindow(g_app.hwnd_login, SW_SHOWNORMAL);
+    UpdateWindow(g_app.hwnd_login);
+}
+
+static void clear_authenticated_session_data(void)
+{
+    ZeroMemory(&g_app.patient, sizeof(g_app.patient));
+    g_app.has_patient = 0;
+    g_app.sim_paused = 0;
+    g_app.session_locked = 0;
+    g_app.reopen_settings_after_unlock = 0;
+    g_app.logged_user[0] = '\0';
+    g_app.logged_username[0] = '\0';
+    g_app.logged_role = ROLE_CLINICAL;
+}
+
+static void logout_authenticated_session(void)
+{
+    HWND dash = g_app.hwnd_dash;
+    HWND settings = g_app.hwnd_settings;
+    HWND pwddlg = g_app.hwnd_pwddlg;
+    HWND adduser = g_app.hwnd_adduser;
+    HWND lock = g_app.hwnd_lock;
+
+    if (pwddlg != NULL)
+        DestroyWindow(pwddlg);
+    if (adduser != NULL)
+        DestroyWindow(adduser);
+    if (settings != NULL)
+        DestroyWindow(settings);
+
+    if (dash != NULL)
+    {
+        KillTimer(dash, TIMER_SIM);
+        KillTimer(dash, TIMER_IDLE);
+    }
+
+    app_config_save(g_app.sim_enabled);
+    open_login_window();
+    clear_authenticated_session_data();
+
+    if (lock != NULL)
+        DestroyWindow(lock);
+    if (dash != NULL)
+        DestroyWindow(dash);
+}
+
+static void session_unlock(HWND w)
+{
+    const int reopen_settings = g_app.reopen_settings_after_unlock;
+
+    g_app.session_locked = 0;
+    g_app.reopen_settings_after_unlock = 0;
+    g_app.last_activity_tick = GetTickCount();
+    ShowWindow(g_app.hwnd_dash, SW_SHOWNORMAL);
+    DestroyWindow(w);
+    SetForegroundWindow(g_app.hwnd_dash);
+
+    if (reopen_settings)
+        open_settings(g_app.hwnd_dash);
+}
+
+static void attempt_unlock(HWND w)
+{
+    char user[USERS_MAX_USERNAME_LEN] = "";
+    char pass[USERS_MAX_PASSWORD_LEN] = "";
+    UserRole role = ROLE_CLINICAL;
+
+    get_txt(w, IDC_LCK_USER, user, (int)sizeof(user));
+    get_txt(w, IDC_LCK_PASS, pass, (int)sizeof(pass));
+
+    if (strcmp(user, g_app.logged_username) == 0 &&
+        auth_validate_role(user, pass, &role) &&
+        role == g_app.logged_role)
+    {
+        session_unlock(w);
+        return;
+    }
+
+    SetWindowTextA(GetDlgItem(w, IDC_LCK_ERR),
+                   "Invalid username or password. Please try again.");
+    SetWindowTextA(GetDlgItem(w, IDC_LCK_PASS), "");
+    SetFocus(GetDlgItem(w, IDC_LCK_PASS));
+}
+
+static void session_lock(HWND dash)
+{
+    if (dash == NULL || g_app.session_locked)
+        return;
+
+    g_app.session_locked = 1;
+    g_app.reopen_settings_after_unlock = (g_app.hwnd_settings != NULL) ? 1 : 0;
+
+    if (g_app.hwnd_pwddlg != NULL)
+        DestroyWindow(g_app.hwnd_pwddlg);
+    if (g_app.hwnd_adduser != NULL)
+        DestroyWindow(g_app.hwnd_adduser);
+    if (g_app.hwnd_settings != NULL)
+        DestroyWindow(g_app.hwnd_settings);
+
+    ShowWindow(dash, SW_HIDE);
+    g_app.hwnd_lock = CreateWindowExA(
+        WS_EX_DLGMODALFRAME|WS_EX_TOPMOST|WS_EX_APPWINDOW,
+        CLASS_LOCK, APP_TITLE,
+        WS_OVERLAPPED|WS_CAPTION|WS_SYSMENU,
+        CW_USEDEFAULT, CW_USEDEFAULT, 420, 320,
+        NULL, NULL, g_app.inst, NULL);
+    ShowWindow(g_app.hwnd_lock, SW_SHOWNORMAL);
+    UpdateWindow(g_app.hwnd_lock);
+    SetForegroundWindow(g_app.hwnd_lock);
+}
+
 /* ===================================================================
  * Dashboard: controls
  * =================================================================== */
@@ -880,6 +1055,8 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 {
     static HWND hw_tab, hw_list;
     static HWND hw_btn_add, hw_btn_edit, hw_btn_rem, hw_btn_pwd;
+    static HWND session_ctrls[8];
+    static int  session_count = 0;
     static HWND sim_ctrls[6];
     static int  sim_count  = 0;
     static HWND about_ctrls[8];
@@ -893,6 +1070,8 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
     /* Language tab control handles @req SWR-GUI-012 */
     static HWND lang_ctrls[4];
     static int  lang_count = 0;
+
+    session_track_message(msg);
 
     switch (msg) {
     case WM_CREATE: {
@@ -910,16 +1089,18 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
         if (g_app.logged_role == ROLE_ADMIN) {
             ti.pszText = (char*)localization_get_string(STR_USER_MANAGEMENT);
                                           TabCtrl_InsertItem(hw_tab, 0, &ti);
-            ti.pszText = (char*)localization_get_string(STR_SIM_MODE);
+            ti.pszText = "Session";
                                           TabCtrl_InsertItem(hw_tab, 1, &ti);
-            ti.pszText = (char*)localization_get_string(STR_ABOUT);
+            ti.pszText = (char*)localization_get_string(STR_SIM_MODE);
                                           TabCtrl_InsertItem(hw_tab, 2, &ti);
-            ti.pszText = (char*)localization_get_string(STR_ALARM_LIMITS);
+            ti.pszText = (char*)localization_get_string(STR_ABOUT);
                                           TabCtrl_InsertItem(hw_tab, 3, &ti);
-            ti.pszText = (char*)localization_get_string(STR_MY_ACCOUNT);
+            ti.pszText = (char*)localization_get_string(STR_ALARM_LIMITS);
                                           TabCtrl_InsertItem(hw_tab, 4, &ti);
-            ti.pszText = (char*)localization_get_string(STR_LANGUAGE);
+            ti.pszText = (char*)localization_get_string(STR_MY_ACCOUNT);
                                           TabCtrl_InsertItem(hw_tab, 5, &ti);
+            ti.pszText = (char*)localization_get_string(STR_LANGUAGE);
+                                          TabCtrl_InsertItem(hw_tab, 6, &ti);
         } else {
             /* Clinical users: no Users tab */
             ti.pszText = (char*)localization_get_string(STR_SIM_MODE);
@@ -946,6 +1127,36 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
         EnableWindow(hw_btn_edit, FALSE);
         EnableWindow(hw_btn_rem,  FALSE);
         EnableWindow(hw_btn_pwd,  FALSE);
+
+        /* --- Session tab controls @req SWR-GUI-014 --- */
+        session_count = 0;
+        session_ctrls[session_count++] = make_label(w,
+            "Session Security",
+            16, 58, 520, 22);
+        session_ctrls[session_count++] = make_label(w,
+            "Configure how many idle minutes are allowed before the current\r\n"
+            "session locks and requires the same user to re-authenticate.",
+            16, 86, 520, 40);
+        session_ctrls[session_count++] = make_label(w,
+            "Idle timeout (minutes):",
+            16, 140, 180, 18);
+        {
+            char timeout_buf[16];
+            snprintf(timeout_buf, sizeof(timeout_buf), "%d",
+                     g_app.idle_timeout_minutes);
+            session_ctrls[session_count++] = make_edit(w,
+                IDC_EDT_IDLE_TIMEOUT, timeout_buf, 16, 160, 80, 24);
+        }
+        session_ctrls[session_count++] = make_label(w,
+            "Allowed range: 1 to 30 minutes. Invalid values are saved as 5.",
+            16, 196, 520, 20);
+        session_ctrls[session_count++] = make_btn(w, IDC_BTN_IDLE_APPLY,
+            "Apply & Save", 16, 228, 120, 28);
+        session_ctrls[session_count++] = make_label(w,
+            "The saved value applies immediately to all authenticated sessions.",
+            16, 268, 520, 20);
+        for (i = 0; i < session_count; ++i)
+            ShowWindow(session_ctrls[i], SW_HIDE);
 
         /* --- Simulation tab controls @req SWR-GUI-010 --- */
         sim_count = 0;
@@ -1118,6 +1329,16 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             SendMessage(sim_ctrls[0],   WM_SETFONT, (WPARAM)g_app.font_status, TRUE);
 
         settings_refresh_list(hw_list);
+        TabCtrl_SetCurSel(hw_tab, 0);
+        if (g_app.logged_role != ROLE_ADMIN) {
+            ShowWindow(hw_list, SW_HIDE);
+            ShowWindow(hw_btn_add, SW_HIDE);
+            ShowWindow(hw_btn_edit, SW_HIDE);
+            ShowWindow(hw_btn_rem, SW_HIDE);
+            ShowWindow(hw_btn_pwd, SW_HIDE);
+            for (i = 0; i < sim_count; ++i)
+                ShowWindow(sim_ctrls[i], SW_SHOW);
+        }
         return 0;
     }
 
@@ -1139,16 +1360,17 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             int sel = TabCtrl_GetCurSel(hw_tab);
             int i;
             /* Map tab index to content: depends on role */
-            int show_users=SW_HIDE, show_sim=SW_HIDE, show_about=SW_HIDE,
+            int show_users=SW_HIDE, show_session=SW_HIDE, show_sim=SW_HIDE, show_about=SW_HIDE,
                 show_alm=SW_HIDE, show_acct=SW_HIDE, show_lang=SW_HIDE;
             if (g_app.logged_role == ROLE_ADMIN) {
-                /* Admin tabs: 0=Users, 1=Sim, 2=About, 3=Alarm, 4=MyAccount, 5=Language */
+                /* Admin tabs: 0=Users, 1=Session, 2=Sim, 3=About, 4=Alarm, 5=MyAccount, 6=Language */
                 if (sel==0) show_users=SW_SHOW;
-                if (sel==1) show_sim=SW_SHOW;
-                if (sel==2) show_about=SW_SHOW;
-                if (sel==3) show_alm=SW_SHOW;
-                if (sel==4) show_acct=SW_SHOW;
-                if (sel==5) show_lang=SW_SHOW;
+                if (sel==1) show_session=SW_SHOW;
+                if (sel==2) show_sim=SW_SHOW;
+                if (sel==3) show_about=SW_SHOW;
+                if (sel==4) show_alm=SW_SHOW;
+                if (sel==5) show_acct=SW_SHOW;
+                if (sel==6) show_lang=SW_SHOW;
             } else {
                 /* Clinical tabs: 0=Sim, 1=Alarm, 2=MyAccount, 3=About, 4=Language */
                 if (sel==0) show_sim=SW_SHOW;
@@ -1162,6 +1384,8 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             ShowWindow(hw_btn_edit,show_users);
             ShowWindow(hw_btn_rem, show_users);
             ShowWindow(hw_btn_pwd, show_users);
+            for (i = 0; i < session_count; ++i)
+                ShowWindow(session_ctrls[i], show_session);
             for (i = 0; i < sim_count;   ++i)
                 ShowWindow(sim_ctrls[i],   show_sim);
             for (i = 0; i < about_count; ++i)
@@ -1193,6 +1417,38 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 
     case WM_COMMAND:
         switch (LOWORD(wp)) {
+        case IDC_BTN_IDLE_APPLY: {
+            char buf[32];
+            char trailing[2];
+            int requested = SESSION_TIMEOUT_DEFAULT_MINUTES;
+            int normalized = SESSION_TIMEOUT_DEFAULT_MINUTES;
+
+            get_txt(w, IDC_EDT_IDLE_TIMEOUT, buf, (int)sizeof(buf));
+            if (sscanf(buf, "%d%1s", &requested, trailing) != 1)
+                requested = SESSION_TIMEOUT_DEFAULT_MINUTES - 1;
+
+            normalized = session_timeout_normalize_minutes(requested);
+            g_app.idle_timeout_minutes = normalized;
+            snprintf(buf, sizeof(buf), "%d", normalized);
+            set_txt(w, IDC_EDT_IDLE_TIMEOUT, buf);
+            session_note_activity();
+
+            if (!app_config_save_idle_timeout_minutes(normalized))
+            {
+                MessageBoxA(w, "Unable to save the idle timeout.",
+                            "Session Settings", MB_OK|MB_ICONWARNING);
+                return 0;
+            }
+
+            if (session_timeout_is_valid_minutes(requested))
+                MessageBoxA(w, "Idle timeout saved.",
+                            "Session Settings", MB_OK|MB_ICONINFORMATION);
+            else
+                MessageBoxA(w,
+                            "Invalid idle timeout. Default 5 minutes was saved.",
+                            "Session Settings", MB_OK|MB_ICONWARNING);
+            return 0;
+        }
         case IDC_ALM_BTN_APPLY: {   /* @req SWR-ALM-001 */
             char buf[32]; double dv; int iv;
             AlarmLimits tmp;
@@ -1360,8 +1616,11 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 
     case WM_DESTROY:
         g_app.hwnd_settings = NULL;
-        EnableWindow(g_app.hwnd_dash, TRUE);
-        SetForegroundWindow(g_app.hwnd_dash);
+        if (g_app.hwnd_dash != NULL) {
+            EnableWindow(g_app.hwnd_dash, TRUE);
+            if (!g_app.session_locked)
+                SetForegroundWindow(g_app.hwnd_dash);
+        }
         return 0;
     }
     return DefWindowProcA(w, msg, wp, lp);
@@ -1372,6 +1631,8 @@ static LRESULT CALLBACK settings_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
  * =================================================================== */
 static LRESULT CALLBACK pwddlg_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 {
+    session_track_message(msg);
+
     switch (msg) {
     case WM_CREATE: {
         int admin = g_pwd_ctx.admin_mode;
@@ -1487,8 +1748,11 @@ static LRESULT CALLBACK pwddlg_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
         HWND parent = (g_app.hwnd_settings != NULL) ? g_app.hwnd_settings
                                                      : g_app.hwnd_dash;
         g_app.hwnd_pwddlg = NULL;
-        EnableWindow(parent, TRUE);
-        SetForegroundWindow(parent);
+        if (parent != NULL) {
+            EnableWindow(parent, TRUE);
+            if (!g_app.session_locked)
+                SetForegroundWindow(parent);
+        }
         return 0;
     }
     }
@@ -1500,6 +1764,8 @@ static LRESULT CALLBACK pwddlg_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
  * =================================================================== */
 static LRESULT CALLBACK adduser_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 {
+    session_track_message(msg);
+
     switch (msg) {
     case WM_CREATE: {
         HWND cmb;
@@ -1597,10 +1863,89 @@ static LRESULT CALLBACK adduser_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 
     case WM_DESTROY:
         g_app.hwnd_adduser = NULL;
-        EnableWindow(g_app.hwnd_settings, TRUE);
-        SetForegroundWindow(g_app.hwnd_settings);
+        if (g_app.hwnd_settings != NULL) {
+            EnableWindow(g_app.hwnd_settings, TRUE);
+            if (!g_app.session_locked)
+                SetForegroundWindow(g_app.hwnd_settings);
+        }
         return 0;
     }
+    return DefWindowProcA(w, msg, wp, lp);
+}
+
+/* ===================================================================
+ * Locked-session dialog
+ * =================================================================== */
+static LRESULT CALLBACK lock_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
+{
+    (void)lp;
+
+    switch (msg) {
+    case WM_CREATE: {
+        HWND ed;
+
+        g_app.hwnd_lock = w;
+        make_label(w,
+                   "Session locked after inactivity. Re-enter credentials to continue.",
+                   20, 54, 360, 36);
+        make_label(w, "Username:", 20, 104, 360, 18);
+        make_edit(w, IDC_LCK_USER, g_app.logged_username, 20, 124, 360, 28);
+        make_label(w, "Password:", 20, 160, 360, 18);
+        ed = CreateWindowExA(WS_EX_CLIENTEDGE, "EDIT", "",
+            WS_CHILD|WS_VISIBLE|WS_TABSTOP|ES_AUTOHSCROLL|ES_PASSWORD,
+            20, 180, 360, 28, w, (HMENU)(INT_PTR)IDC_LCK_PASS, g_app.inst, NULL);
+        SendMessage(ed, EM_SETPASSWORDCHAR, (WPARAM)'*', 0);
+        CreateWindowExA(0, "STATIC", "", WS_CHILD|WS_VISIBLE|SS_LEFT,
+            20, 218, 360, 18, w, (HMENU)(INT_PTR)IDC_LCK_ERR, g_app.inst, NULL);
+        CreateWindowExA(0, "BUTTON", "Unlock Session",
+            WS_CHILD|WS_VISIBLE|WS_TABSTOP|BS_DEFPUSHBUTTON,
+            20, 246, 170, 28, w, (HMENU)(INT_PTR)IDC_LCK_BTN_UNLOCK, g_app.inst, NULL);
+        make_btn(w, IDC_LCK_BTN_LOGOUT, localization_get_string(STR_LOGOUT),
+                 206, 246, 174, 28);
+        font_children(w, g_app.font_ui);
+        SetFocus(GetDlgItem(w, IDC_LCK_PASS));
+        return 0;
+    }
+
+    case WM_PAINT: {
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(w, &ps);
+        fill_rect(hdc, 0, 0, 420, 40, CLR_NAVY);
+        draw_text_ex(hdc, "  Session Locked", 0, 0, 420, 40,
+                     g_app.font_status, CLR_WHITE,
+                     DT_SINGLELINE|DT_VCENTER|DT_LEFT);
+        EndPaint(w, &ps);
+        return 0;
+    }
+
+    case WM_CTLCOLORSTATIC:
+        if ((HWND)lp == GetDlgItem(w, IDC_LCK_ERR)) {
+            SetTextColor((HDC)wp, CLR_CR_FG);
+            SetBkMode((HDC)wp, TRANSPARENT);
+            return (LRESULT)GetStockObject(NULL_BRUSH);
+        }
+        break;
+
+    case WM_COMMAND:
+        switch (LOWORD(wp)) {
+        case IDC_LCK_BTN_UNLOCK:
+            attempt_unlock(w);
+            return 0;
+        case IDC_LCK_BTN_LOGOUT:
+            logout_authenticated_session();
+            return 0;
+        }
+        break;
+
+    case WM_CLOSE:
+        logout_authenticated_session();
+        return 0;
+
+    case WM_DESTROY:
+        g_app.hwnd_lock = NULL;
+        return 0;
+    }
+
     return DefWindowProcA(w, msg, wp, lp);
 }
 
@@ -1717,6 +2062,8 @@ static void refresh_dash_language(HWND w)
  * =================================================================== */
 static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 {
+    session_track_message(msg);
+
     switch (msg) {
     case WM_CREATE: {
         VitalSigns first_v;
@@ -1737,9 +2084,14 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             int lang = app_config_load_language();
             localization_set_language((Language)lang);
         }
+        g_app.idle_timeout_minutes = app_config_load_idle_timeout_minutes();
+        g_app.session_locked = 0;
+        g_app.reopen_settings_after_unlock = 0;
+        g_app.last_activity_tick = GetTickCount();
         alarm_limits_load(&g_app.alarm_limits);       /* restore alarm limits @req SWR-ALM-001 */
         hw_init();
         g_app.sim_paused = 0;
+        SetTimer(w, TIMER_IDLE, 1000, NULL);
 
         /* Pause Sim and demo buttons only visible when simulation is active */
         ShowWindow(GetDlgItem(w, IDC_BTN_PAUSE), g_app.sim_enabled ? SW_SHOW : SW_HIDE);
@@ -1798,6 +2150,13 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             g_app.sim_msg_scroll_offset = (g_app.sim_msg_scroll_offset + 3) % 800;
             update_dashboard(w);
         }
+        if (wp == TIMER_IDLE &&
+            !g_app.session_locked &&
+            session_timeout_has_expired((uint32_t)g_app.last_activity_tick,
+                                        (uint32_t)GetTickCount(),
+                                        g_app.idle_timeout_minutes)) {
+            session_lock(w);
+        }
         return 0;
 
     case WM_ERASEBKGND: {
@@ -1839,26 +2198,14 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             open_settings(w);
             return 0;
         case IDC_BTN_LOGOUT:
-            KillTimer(w, TIMER_SIM);
-            app_config_save(g_app.sim_enabled);
-            ZeroMemory(&g_app.patient, sizeof(g_app.patient));
-            g_app.has_patient    = 0;
-            g_app.sim_paused     = 0;
-            g_app.logged_user[0] = '\0';
-            g_app.logged_username[0] = '\0';
-            g_app.hwnd_login = CreateWindowExA(
-                WS_EX_APPWINDOW, CLASS_LOGIN, APP_TITLE,
-                WS_OVERLAPPED|WS_CAPTION|WS_SYSMENU,
-                CW_USEDEFAULT,CW_USEDEFAULT,440,520,
-                NULL,NULL,g_app.inst,NULL);
-            ShowWindow(g_app.hwnd_login, SW_SHOWNORMAL);
-            DestroyWindow(w);
+            logout_authenticated_session();
             return 0;
         }
         break;
 
     case WM_DESTROY:
         KillTimer(w, TIMER_SIM);
+        KillTimer(w, TIMER_IDLE);
         g_app.hwnd_dash = NULL;
         if (g_app.hwnd_login == NULL) PostQuitMessage(0);
         return 0;
@@ -2076,6 +2423,7 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmd, int show)
     wc.lpfnWndProc   = settings_proc; wc.lpszClassName = CLASS_SETTINGS; RegisterClassExA(&wc);
     wc.lpfnWndProc   = pwddlg_proc;   wc.lpszClassName = CLASS_PWDDLG;   RegisterClassExA(&wc);
     wc.lpfnWndProc   = adduser_proc;  wc.lpszClassName = CLASS_ADDUSER;  RegisterClassExA(&wc);
+    wc.lpfnWndProc   = lock_proc;     wc.lpszClassName = CLASS_LOCK;     RegisterClassExA(&wc);
 
     g_app.hwnd_login = CreateWindowExA(
         WS_EX_APPWINDOW, CLASS_LOGIN, APP_TITLE,
@@ -2090,6 +2438,7 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmd, int show)
         if (g_app.hwnd_settings && IsDialogMessage(g_app.hwnd_settings, &msg)) continue;
         if (g_app.hwnd_pwddlg   && IsDialogMessage(g_app.hwnd_pwddlg,  &msg)) continue;
         if (g_app.hwnd_adduser  && IsDialogMessage(g_app.hwnd_adduser,  &msg)) continue;
+        if (g_app.hwnd_lock     && IsDialogMessage(g_app.hwnd_lock,     &msg)) continue;
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }

--- a/src/session_timeout.c
+++ b/src/session_timeout.c
@@ -1,0 +1,36 @@
+/**
+ * @file session_timeout.c
+ * @brief Idle session-timeout policy helpers.
+ *
+ * @req SWR-SEC-005
+ */
+
+#include "session_timeout.h"
+
+int session_timeout_is_valid_minutes(int minutes)
+{
+    return (minutes >= SESSION_TIMEOUT_MIN_MINUTES &&
+            minutes <= SESSION_TIMEOUT_MAX_MINUTES) ? 1 : 0;
+}
+
+int session_timeout_normalize_minutes(int minutes)
+{
+    return session_timeout_is_valid_minutes(minutes)
+        ? minutes
+        : SESSION_TIMEOUT_DEFAULT_MINUTES;
+}
+
+uint32_t session_timeout_duration_ms(int minutes)
+{
+    const uint32_t normalized =
+        (uint32_t)session_timeout_normalize_minutes(minutes);
+    return normalized * 60u * 1000u;
+}
+
+int session_timeout_has_expired(uint32_t last_activity_tick,
+                                uint32_t now_tick,
+                                int minutes)
+{
+    const uint32_t elapsed = now_tick - last_activity_tick;
+    return (elapsed >= session_timeout_duration_ms(minutes)) ? 1 : 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(test_unit
     unit/test_auth.cpp
     unit/test_hal.cpp
     unit/test_config.cpp
+    unit/test_session_timeout.cpp
     unit/test_localization.cpp
     unit/test_news2.cpp
     unit/test_alarm_limits.cpp

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -22,6 +22,8 @@
 
 extern "C" {
 #include "app_config.h"
+#include "localization.h"
+#include "session_timeout.h"
 }
 
 // ---------------------------------------------------------------------------
@@ -250,4 +252,80 @@ TEST_F(ConfigTest, NonZeroValueTreatedAsEnabled)
     int result = app_config_load(&sim_enabled);
     EXPECT_EQ(1, result);
     EXPECT_EQ(1, sim_enabled) << "Any non-zero value should be normalised to 1";
+}
+
+// @req SWR-GUI-014 - Missing idle-timeout config falls back to approved default
+TEST_F(ConfigTest, IdleTimeoutDefaultsWhenFileAbsent)
+{
+    std::string nonexistent = temp_path_ + "_idle_missing";
+    std::remove(nonexistent.c_str());
+    app_config_set_path(nonexistent.c_str());
+
+    EXPECT_EQ(SESSION_TIMEOUT_DEFAULT_MINUTES,
+              app_config_load_idle_timeout_minutes());
+
+    std::remove(nonexistent.c_str());
+}
+
+// @req SWR-GUI-014 - Saved idle timeout is reloaded unchanged when valid
+TEST_F(ConfigTest, SaveIdleTimeoutThenLoadReturnsSavedValue)
+{
+    ASSERT_EQ(1, app_config_save_idle_timeout_minutes(12));
+    EXPECT_EQ(12, app_config_load_idle_timeout_minutes());
+}
+
+// @req SWR-GUI-014 - Saving idle timeout preserves existing sim and language keys
+TEST_F(ConfigTest, SaveIdleTimeoutPreservesSimulationAndLanguage)
+{
+    ASSERT_EQ(1, app_config_save(0));
+    ASSERT_EQ(1, app_config_save_language(LOC_LANG_GERMAN));
+    ASSERT_EQ(1, app_config_save_idle_timeout_minutes(9));
+
+    int sim_enabled = 99;
+    ASSERT_EQ(1, app_config_load(&sim_enabled));
+    EXPECT_EQ(0, sim_enabled);
+    EXPECT_EQ(LOC_LANG_GERMAN, app_config_load_language());
+    EXPECT_EQ(9, app_config_load_idle_timeout_minutes());
+}
+
+// @req SWR-GUI-014 - Saving language preserves the persisted idle timeout
+TEST_F(ConfigTest, SaveLanguagePreservesIdleTimeout)
+{
+    ASSERT_EQ(1, app_config_save_idle_timeout_minutes(14));
+    ASSERT_EQ(1, app_config_save_language(LOC_LANG_SPANISH));
+
+    EXPECT_EQ(LOC_LANG_SPANISH, app_config_load_language());
+    EXPECT_EQ(14, app_config_load_idle_timeout_minutes());
+}
+
+// @req SWR-GUI-014 - Saving sim mode preserves the persisted idle timeout
+TEST_F(ConfigTest, SaveSimulationModePreservesIdleTimeout)
+{
+    ASSERT_EQ(1, app_config_save_idle_timeout_minutes(18));
+    ASSERT_EQ(1, app_config_save(0));
+
+    int sim_enabled = 99;
+    ASSERT_EQ(1, app_config_load(&sim_enabled));
+    EXPECT_EQ(0, sim_enabled);
+    EXPECT_EQ(18, app_config_load_idle_timeout_minutes());
+}
+
+// @req SWR-SEC-005 - Malformed idle-timeout config falls back to the default
+TEST_F(ConfigTest, MalformedIdleTimeoutFallsBackToDefault)
+{
+    FILE *f = fopen(temp_path_.c_str(), "w");
+    ASSERT_NE(nullptr, f);
+    fprintf(f, "idle_timeout_minutes=abc\n");
+    fclose(f);
+
+    EXPECT_EQ(SESSION_TIMEOUT_DEFAULT_MINUTES,
+              app_config_load_idle_timeout_minutes());
+}
+
+// @req SWR-SEC-005 - Invalid saved idle-timeout values are normalized to the default
+TEST_F(ConfigTest, SavingInvalidIdleTimeoutPersistsDefault)
+{
+    ASSERT_EQ(1, app_config_save_idle_timeout_minutes(0));
+    EXPECT_EQ(SESSION_TIMEOUT_DEFAULT_MINUTES,
+              app_config_load_idle_timeout_minutes());
 }

--- a/tests/unit/test_session_timeout.cpp
+++ b/tests/unit/test_session_timeout.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file test_session_timeout.cpp
+ * @brief Unit tests for idle session-timeout helpers.
+ *
+ * @req SWR-SEC-005  Idle timeout validation and expiry logic.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+extern "C" {
+#include "session_timeout.h"
+}
+
+TEST(SessionTimeoutBounds, AcceptsApprovedBounds)
+{
+    EXPECT_EQ(1, session_timeout_is_valid_minutes(SESSION_TIMEOUT_MIN_MINUTES));
+    EXPECT_EQ(1, session_timeout_is_valid_minutes(SESSION_TIMEOUT_MAX_MINUTES));
+}
+
+TEST(SessionTimeoutBounds, RejectsValuesOutsideApprovedRange)
+{
+    EXPECT_EQ(0, session_timeout_is_valid_minutes(0));
+    EXPECT_EQ(0, session_timeout_is_valid_minutes(-5));
+    EXPECT_EQ(0, session_timeout_is_valid_minutes(SESSION_TIMEOUT_MAX_MINUTES + 1));
+}
+
+TEST(SessionTimeoutBounds, NormalizesInvalidValueToDefault)
+{
+    EXPECT_EQ(SESSION_TIMEOUT_DEFAULT_MINUTES,
+              session_timeout_normalize_minutes(0));
+    EXPECT_EQ(SESSION_TIMEOUT_DEFAULT_MINUTES,
+              session_timeout_normalize_minutes(99));
+}
+
+TEST(SessionTimeoutBounds, PreservesValidConfiguredValue)
+{
+    EXPECT_EQ(7, session_timeout_normalize_minutes(7));
+    EXPECT_EQ(SESSION_TIMEOUT_MAX_MINUTES,
+              session_timeout_normalize_minutes(SESSION_TIMEOUT_MAX_MINUTES));
+}
+
+TEST(SessionTimeoutTiming, DurationUsesNormalizedMinutes)
+{
+    EXPECT_EQ(5u * 60u * 1000u, session_timeout_duration_ms(5));
+    EXPECT_EQ((uint32_t)SESSION_TIMEOUT_DEFAULT_MINUTES * 60u * 1000u,
+              session_timeout_duration_ms(0));
+}
+
+TEST(SessionTimeoutTiming, NotExpiredBeforeThreshold)
+{
+    const uint32_t last_tick = 1000u;
+    const uint32_t now_tick = last_tick + session_timeout_duration_ms(3) - 1u;
+
+    EXPECT_EQ(0, session_timeout_has_expired(last_tick, now_tick, 3));
+}
+
+TEST(SessionTimeoutTiming, ExpiresAtThresholdAndAcrossTickWrap)
+{
+    const uint32_t duration = session_timeout_duration_ms(1);
+
+    EXPECT_EQ(1, session_timeout_has_expired(2000u, 2000u + duration, 1));
+    EXPECT_EQ(1, session_timeout_has_expired(0xFFFFFF00u,
+                                             0xFFFFFF00u + duration,
+                                             1));
+}


### PR DESCRIPTION
Closes #60

## Spec
- `docs/history/specs/60-make-clinician-idle-timeout-configurable.md`

## Summary of changes
- adds the `session_timeout` helper module and unit coverage for timeout bounds, normalization, duration, and expiry
- persists `idle_timeout_minutes` in `monitor.cfg` while preserving existing simulation and language settings
- adds an admin-only Session settings tab plus a locked-session re-authentication flow in `src/gui_main.c`
- updates `UNS-013`, `UNS-016`, `SYS-022`, `SWR-GUI-014`, `SWR-SEC-005`, and traceability rows for the new access-control behavior

## Requirements and traceability impact
- extends `UNS-013` and `UNS-016` for unattended-session protection and admin-only policy control
- adds `SYS-022` for configurable idle session locking
- adds `SWR-GUI-014` and `SWR-SEC-005`
- updates `requirements/TRACEABILITY.md` to map persistence and timeout evidence to the new requirement rows

## Commands run
- `git -C 'D:\Claude\AGX-PRI\medvital-monitor\agentry\worktrees\implementer' rebase origin/main` -> already up to date
- `cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DBUILD_TESTS=ON -Wno-dev` -> PASS
- `cmake --build build --target test_unit test_integration` -> PASS
- `ctest --test-dir build --output-on-failure` -> PASS (`2/2` suites passed)
- `python dvt/run_dvt.py --no-build --build-dir build` -> PASS (`test_unit`: `307` tests, `test_integration`: `14` tests, DVT overall PASS)

## Skipped checks and why
- `run_tests.bat` skipped because the script ends with an unconditional `pause`, which would block non-interactive automation; equivalent unit/integration coverage was executed via build, `ctest`, and DVT
- `run_coverage.bat` skipped because `gcovr` is not installed on the host (`where gcovr` returned no match); the tester matrix only requires that row when GCC coverage and `gcovr` are available
- manual GUI verification is still pending for admin-only Session-tab visibility, persisted restart behavior, idle lock timing, patient-content obscuring, and unlock flow because this run was terminal-only

## Medical-safety and security notes
- scope remains local access control only; no AI/ML behavior or clinical calculation logic was added
- automated evidence covers timeout bounds, fallback-to-default persistence, and the non-logout lock path support code
- manual GUI verification is still needed to confirm the locked state obscures patient content while preserving session context and monitoring behavior

## AI/ML impact and evidence
- none
