### PR TITLE
Feature: show current alert duration beside the status pill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The pipeline (`.github/workflows/pipeline.yml`) enforces this sequence — each 
 
 1. **Build All** — CMake + Ninja, all targets (Windows / MinGW-w64)
 2. **Static Analysis + SAST** — cppcheck + CodeQL (parallel, both gate on build)
-3. **Unit & Integration Tests** — GTest, 307 test cases
+3. **Unit & Integration Tests** — GTest, 317 test cases
 4. **Code Coverage** — gcovr, source-level line + branch coverage
 5. **DVT** — Design Verification Tests with IEC 62304 report
 6. **Publish Reports** — GitHub Pages dashboard (main branch only)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(monitor_lib STATIC
     src/news2.c
     src/alarm_limits.c
     src/trend.c
+    src/gui_status_duration.c
     src/localization.c
 )
 target_include_directories(monitor_lib PUBLIC include)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Medical device software for real-time patient vital sign monitoring and alert generation.
 Built to **IEC 62304 Class B** and **FDA SW Validation Guidance** standards.
-**Version 2.7.0** — Six vital signs (including respiration rate), NEWS2 early warning score, configurable alarm limits (IEC 60601-1-8), trend sparkline graphs, a session alarm event review log, role-based settings access, rolling status message in simulation mode, 293 unit + 14 integration tests (307 total).
+**Version 2.7.0** — Six vital signs (including respiration rate), NEWS2 early warning score, configurable alarm limits (IEC 60601-1-8), trend sparkline graphs, a session alarm event review log, role-based settings access, a current alert-state duration cue in the dashboard banner, rolling status message in simulation mode, 303 unit + 14 integration tests (317 total).
 
 ---
 
@@ -327,7 +327,7 @@ from a terminal.
 | Script                 | What it does                                                          |
 |------------------------|-----------------------------------------------------------------------|
 | `build.bat`            | Configure + build everything (first run or incremental). Launches GUI.|
-| `run_tests.bat`        | Rebuild test targets and run all 307 tests. Exits non-zero on failure.|
+| `run_tests.bat`        | Rebuild test targets and run all 317 tests. Exits non-zero on failure.|
 | `run_coverage.bat`     | Build with `--coverage`, run tests, generate HTML + XML reports.      |
 | `generate_docs.bat`    | Run Doxygen to produce HTML + XML design documentation.               |
 | `create_installer.bat` | Build release exe + compile Windows installer (`dist\` folder).       |
@@ -469,9 +469,10 @@ requirements revision.
 | `tests/unit/test_hal.cpp`                       | 12     | Supporting HAL / simulator checks only |
 | `tests/unit/test_config.cpp`                    | 10     | Supporting config persistence checks only |
 | `tests/unit/test_localization.cpp`              | 8      | SWR-GUI-012                       |
+| `tests/unit/test_gui_status_duration.cpp`       | 10     | SWR-GUI-014                       |
 | `tests/integration/test_patient_monitoring.cpp` | 7      | SWR-PAT-*, SWR-VIT-*, SWR-ALT-*   |
 | `tests/integration/test_alert_escalation.cpp`   | 7      | SWR-VIT-*, SWR-ALT-*, SWR-PAT-007 |
-| **Total**                                       | **307** | **40 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
+| **Total**                                       | **317** | **41 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
 
 ### Test techniques applied
 
@@ -601,6 +602,7 @@ Opens `docs\html\index.html` automatically.
 | SWR-GUI-007     | `gui_users.c`/`gui_main.c`| `test_auth.cpp` — UserManagement |
 | SWR-GUI-008-010 | `gui_main.c`, `app_config.c`| `test_config.cpp` + visual    |
 | SWR-GUI-011     | `gui_main.c`              | GUI demonstration                |
+| SWR-GUI-014     | `gui_status_duration.c`, `gui_main.c` | `test_gui_status_duration.cpp` + GUI demonstration |
 | SWR-INT-MON     | All modules               | `test_patient_monitoring.cpp`    |
 | SWR-INT-ESC     | All modules               | `test_alert_escalation.cpp`      |
 
@@ -655,7 +657,8 @@ medvital-monitor/
 │   │   ├── test_trend.cpp           # 18 tests — SWR-TRD-001
 │   │   ├── test_hal.cpp             # 12 tests — SWR-GUI-005/006
 │   │   ├── test_config.cpp          # 10 tests — SWR-GUI-010
-│   │   └── test_localization.cpp    # 8 tests — SWR-GUI-012
+│   │   ├── test_localization.cpp    # 8 tests — SWR-GUI-012
+│   │   └── test_gui_status_duration.cpp  # 10 tests — SWR-GUI-014
 │   └── integration/
 │       ├── test_patient_monitoring.cpp  # 7 tests — SWR-PAT-*, SWR-VIT-*, SWR-ALT-*
 │       └── test_alert_escalation.cpp    # 7 tests — SWR-VIT-*, SWR-ALT-*, SWR-PAT-007
@@ -663,11 +666,11 @@ medvital-monitor/
 ├── requirements/
 |   |-- UNS.md                       # User Needs (17 items)
 |   |-- SYS.md                       # System Requirements (21 items)
-│   ├── SWR.md                       # Software Requirements (40 items)
-│   └── TRACEABILITY.md              # RTM — 17/17 UNS, 40/40 SWR, 307 tests
+│   ├── SWR.md                       # Software Requirements (41 items)
+│   └── TRACEABILITY.md              # RTM — 17/17 UNS, 41/41 SWR, 317 tests
 │
 ├── build.bat                        # Configure + build + launch GUI
-|-- run_tests.bat                    # Run all 307 tests
+|-- run_tests.bat                    # Run all 317 tests
 ├── run_coverage.bat                 # GCC coverage report (gcov + gcovr)
 ├── generate_docs.bat                # Doxygen HTML + XML documentation
 ├── create_installer.bat             # Build release + compile Windows installer

--- a/docs/history/risk/65-show-current-alert-duration-beside-the-status-pill.md
+++ b/docs/history/risk/65-show-current-alert-duration-beside-the-status-pill.md
@@ -1,0 +1,247 @@
+# Risk Note: Issue #65
+
+Date: 2026-05-06
+Issue: `#65` - Feature: show current alert duration beside the status pill
+Branch: `feature/65-show-current-alert-duration-beside-the-status-pill`
+
+## proposed change
+
+Add a display-only duration cue beside the existing aggregate status pill so the
+dashboard can show how long the current abnormal aggregate state has been
+active. The intended scope is limited to presentation of the existing
+`patient_current_status()` result and its state-transition timing. The change
+must not alter alert thresholds, aggregate severity rules, NEWS2 scoring,
+audible behavior, acknowledgement workflow, or patient-record persistence.
+
+## product hypothesis and intended user benefit
+
+The product hypothesis is that operators can triage the current dashboard more
+quickly if the aggregate status area answers two questions at once: severity
+(`WARNING` or `CRITICAL`) and freshness (`for 00:40` versus `for 12:15`). The
+expected benefit is faster scan interpretation during monitoring review and
+handoff, especially when a persistent abnormal state is clinically different
+from a newly emerged one.
+
+This is a usability hypothesis, not a clinical-effectiveness claim. The issue
+supports a bounded MVP because it reuses an already computed aggregate state and
+adds no new physiological inference.
+
+## source evidence quality
+
+Source evidence quality is moderate for UX precedent and low for clinical
+justification.
+
+- The cited Philips Patient Information Center iX public IFU is a primary
+  vendor source showing that review-oriented alarm-duration context exists in a
+  commercial monitoring ecosystem. It is useful to justify that the concept is
+  not novel or obviously out of family for monitoring UI.
+- The cited source does not prove improved outcomes, reduced response time, or
+  safe operator behavior for this repository's dashboard. It should not be used
+  as clinical evidence.
+- No comparative usability study, human-factors validation, or alarm-fatigue
+  evidence was provided in the issue. Design should therefore stay conservative
+  and avoid overstating benefit.
+
+## medical-safety impact
+
+The feature is not clinically silent even though it is display-only. A duration
+badge can influence human urgency assessment, handoff prioritization, and
+interpretation of whether a condition is new, persistent, or worsening.
+
+The main safety risk is not threshold corruption; it is misinterpretation. If
+the displayed duration is stale, fails to reset on an aggregate-state change,
+continues during a paused feed, or visually dominates the existing severity
+cue, an operator could under-triage a fresh critical change or over-trust the
+age indicator as if it were a proven measure of physiological onset.
+
+Because the existing dashboard already shows colour, current aggregate status,
+raw vital values, and active alert text, the duration cue is secondary. That
+keeps the overall safety impact bounded, but it still needs explicit design and
+verification controls.
+
+## security and privacy impact
+
+No new patient-data category, credential flow, network path, or privilege
+boundary is required for this feature if it remains local to `gui_main.c` and
+uses existing in-memory patient state.
+
+Privacy impact is none expected. Security impact is low and limited to display
+integrity: the UI must not present misleading elapsed time because operators may
+rely on it operationally. The feature should not create new logging, export,
+persistence, or telemetry behavior without separate review.
+
+## affected requirements or "none"
+
+Likely affected existing requirements if the feature proceeds:
+
+- `SYS-011` Patient Status Summary Display
+- `SYS-014` Graphical Vital Signs Dashboard
+- `SWR-GUI-003` Colour-Coded Vital Signs Display
+- `SWR-PAT-004` Current Patient Status
+
+No change should alter:
+
+- `SYS-001` through `SYS-006` threshold and aggregate-alert logic
+- `SYS-019` NEWS2 aggregate clinical risk scoring
+- `SWR-VIT-*`, `SWR-NEW-001`, or `SWR-ALT-*` clinical classification behavior
+
+The current approved requirements do not explicitly specify an alert-duration
+display. Architect should either map this as a narrow extension to dashboard
+display behavior or propose a tightly scoped requirement update without
+rewriting clinical logic.
+
+## intended use, user population, operating environment, and foreseeable misuse
+
+- Intended use: give trained clinical users a concise age indicator for the
+  currently active abnormal aggregate dashboard state.
+- User population: trained clinicians or operators already using the dashboard
+  for bedside-style monitoring review.
+- Operating environment: Windows workstation dashboard in live simulation today
+  and a future real-monitoring environment through the same aggregate-state
+  display path.
+- Foreseeable misuse: a user may treat the badge as time since physiological
+  onset rather than time since the software entered the current aggregate state.
+- Foreseeable misuse: a user may interpret the duration as acknowledgement,
+  escalation, or muting state even though the product does not implement those
+  workflows.
+- Foreseeable misuse: if the timer keeps running during paused simulation,
+  cleared session, patient refresh, or device mode, a user may assume the
+  monitor continued actively observing the patient during that period.
+
+## severity, probability, initial risk, risk controls, verification method, residual risk, and residual-risk acceptability rationale
+
+- Severity: Moderate. A misleading duration could contribute to delayed or
+  mis-prioritized response, but it does not by itself suppress the existing
+  alert severity, raw values, or active-alert list.
+- Probability: Low to medium before controls because elapsed-time features are
+  prone to reset, rollover, and state-transition defects.
+- Initial risk: Medium.
+- Risk controls:
+  - Derive the timer from aggregate-state transitions only, not from any single
+    underlying vital sign.
+  - Reset the timer whenever the aggregate level changes, the patient/session
+    is cleared, the user logs out, or monitoring mode no longer represents
+    active observation.
+  - Show the badge only for abnormal states, not for `NORMAL`.
+  - Keep the duration visually subordinate to the severity pill and current
+    numeric values.
+  - Label it as elapsed time in the current alert state, not as onset time or
+    treatment timer.
+- Verification method:
+  - Transition tests or targeted verification for `NORMAL -> WARNING`,
+    `WARNING -> CRITICAL`, `CRITICAL -> WARNING`, and abnormal `-> NORMAL`
+    resets.
+  - Manual GUI review confirming the badge never obscures the severity cue and
+    behaves correctly during pause, resume, clear session, admit/refresh, and
+    simulation-mode changes.
+  - Diff review confirming no threshold or alerting logic changed outside the
+    intended presentation/state-tracking scope.
+- Residual risk: Low if the above controls are implemented and verified.
+- Residual-risk acceptability rationale: acceptable for this pilot because the
+  cue remains advisory, redundant with stronger existing alert indicators, and
+  bounded away from thresholding or treatment logic.
+
+## hazards and failure modes
+
+- The timer does not reset when the aggregate level changes from `WARNING` to
+  `CRITICAL`, causing a fresh critical escalation to look old and potentially
+  less urgent.
+- The timer resets on every new reading even while the aggregate level remains
+  unchanged, making persistent deterioration appear fresh.
+- The timer tracks one parameter rather than the aggregate status and diverges
+  from the displayed severity pill.
+- The timer continues through paused simulation, cleared session, logout, or
+  device mode and implies monitoring continuity that did not exist.
+- The badge wording or styling causes users to read it as alarm-acknowledgement
+  age, escalation SLA, or clinically validated onset time.
+- The implementation expands into acknowledgement, muting, history export, or
+  retrospective alarm analytics without additional requirements and review.
+
+## existing controls
+
+- The current product already computes a single aggregate status from the
+  latest reading via `patient_current_status()` and `overall_alert_level()`.
+- The issue explicitly constrains scope to display-only behavior and excludes
+  threshold changes, suppression, and acknowledgement workflow.
+- Existing dashboard cues already include colour, status text, raw vital
+  values, and active-alert messages, reducing dependence on the new duration
+  badge as a sole signal.
+- The current timer-driven dashboard update loop provides a natural place to
+  evaluate aggregate-state transitions without adding network or persistence
+  complexity.
+
+## required design controls
+
+- Define one clear semantics statement in design: the badge shows elapsed time
+  since the software entered the current abnormal aggregate state.
+- Track entered-state time in presentation state only; do not backfill from
+  historical records or infer physiological onset.
+- Reset or clear the badge on every aggregate-level transition, on return to
+  `NORMAL`, on patient/session reset, on logout, and when live monitoring is
+  not active.
+- Keep the existing severity pill as the primary cue. The duration must not
+  replace colour, level text, or the active-alert list.
+- Use a simple bounded format such as `MM:SS` or `HH:MM:SS`; avoid ambiguous
+  wording like "alarm time" unless requirements explicitly define it.
+- Do not add acknowledgement count, alarm muting, trend interpretation, or
+  escalation claims as part of this MVP.
+- If design discovers the need for audit logging, persisted alarm history, or
+  cross-session duration continuity, split that into a separate issue and risk
+  review.
+
+## MVP boundary that avoids copying proprietary UX
+
+- Reuse only the general idea of showing elapsed abnormal-state context.
+- Do not copy vendor terminology, layout, iconography, configuration concepts,
+  or workflow terms from the Philips IFU.
+- Keep the MVP local to the existing aggregate status area and current session.
+- Exclude alarm-advisor logic, acknowledge counters, historical review screens,
+  or configurable duration-trigger behavior.
+
+## clinical-safety boundary and claims that must not be made
+
+- Do not claim the badge measures time since clinical onset, deterioration
+  onset, or treatment delay.
+- Do not claim the feature improves outcomes, reduces alarm fatigue, or supports
+  diagnosis without separate human-factors and clinical evidence.
+- Do not alter or imply changes to alert thresholds, NEWS2, or escalation rules.
+- Do not let the UI suggest that an old `CRITICAL` state is less urgent than a
+  new one; the severity tier remains primary.
+
+## validation expectations
+
+- Verify the duration source of truth is the aggregate dashboard state, not an
+  individual alert row or a single vital-sign threshold path.
+- Exercise manual and automated transition coverage for steady abnormal state,
+  escalation, de-escalation, return to normal, pause/resume, and patient reset.
+- Confirm the badge is absent in `NORMAL` and does not persist into device mode
+  or other non-monitoring states.
+- Review the changed file list to ensure the patch stays within presentation,
+  state-tracking, and narrowly related tests or documentation.
+- Confirm requirements updates, if any, remain display-scope only and do not
+  silently rewrite clinical behavior.
+
+## residual risk for this pilot
+
+Residual risk is low if the feature remains a bounded presentation-layer cue
+with explicit reset semantics and validation of state transitions. Residual risk
+increases to medium if the design leaves duration semantics ambiguous or allows
+the timer to imply continuous observation when the feed is paused or reset.
+
+## whether the candidate is safe to send to Architect
+
+Yes, with the controls above. The issue is sufficiently bounded, the product
+hypothesis is plausible, and the safety boundary is clear enough for Architect
+to design a display-only solution without changing clinical classification
+logic.
+
+## human owner decision needed, if any
+
+No blocking human decision is required to send this to Architect as long as the
+scope stays display-only.
+
+Human product review is still needed if the team wants any of the following:
+
+- persisted alarm-duration history across sessions
+- acknowledgement, mute, or escalation workflow
+- claims about clinical benefit or response-time improvement

--- a/docs/history/specs/65-show-current-alert-duration-beside-the-status-pill.md
+++ b/docs/history/specs/65-show-current-alert-duration-beside-the-status-pill.md
@@ -1,0 +1,299 @@
+# Design Spec: Show current alert duration beside the status pill
+
+Issue: #65
+Branch: `feature/65-show-current-alert-duration-beside-the-status-pill`
+Spec path: `docs/history/specs/65-show-current-alert-duration-beside-the-status-pill.md`
+
+## Problem
+
+Issue #65 asks the dashboard to show how long the current aggregate abnormal
+state has been active so an operator can distinguish a fresh `WARNING` or
+`CRITICAL` change from a persistent one.
+
+The current implementation already computes aggregate severity from the latest
+reading, but it does not expose elapsed time for that state. `patient_current_status()`
+returns only `ALERT_NORMAL`, `ALERT_WARNING`, or `ALERT_CRITICAL`. `VitalSigns`
+and `PatientRecord` contain no timestamps, so the GUI cannot infer a defensible
+"time in state" value from stored readings alone.
+
+That gap is operationally relevant because the dashboard currently answers only
+"how severe is the current state?" and not "how long has this same abnormal
+state been active?" The risk note for #65 correctly narrows the hazard to human
+misinterpretation, not threshold corruption: a stale or misleading duration cue
+could make a fresh escalation look old, or make an old alert look clinically
+validated when it is only a presentation-layer timer.
+
+## Goal
+
+Add a narrow, display-only duration cue beside the aggregate dashboard status
+surface so the operator can see the current abnormal aggregate level and the
+elapsed time since the software entered that same abnormal aggregate state.
+
+The design goal is to make the feature:
+
+- aggregate-state based, not per-parameter based
+- presentation-layer only, with no changes to thresholds or patient-record data
+- clearly subordinate to existing severity colour and text
+- resettable whenever monitoring is no longer actively representing the same
+  abnormal state
+
+## Non-goals
+
+- No changes to `overall_alert_level()`, `patient_current_status()`,
+  `generate_alerts()`, NEWS2 scoring, alarm limits, or audible behavior.
+- No persisted timestamps in `VitalSigns`, `PatientRecord`, or any other domain
+  model.
+- No acknowledgement, muting, escalation, export, audit-history, or alarm
+  analytics workflow.
+- No claim that the cue represents physiological onset time, treatment delay,
+  clinician acknowledgement age, or validated clinical benefit.
+- No extension of this issue into the CLI patient summary in `patient.c`.
+- No reuse of the header's existing role pill (`ADMIN` / `CLINICAL`) as the
+  abnormal-state duration surface.
+
+## Intended use impact, user population, operating environment, and foreseeable misuse
+
+- Intended use impact: provide a concise elapsed-time cue for the current
+  abnormal aggregate dashboard state during active monitoring.
+- User population: trained clinicians or operators already using the dashboard
+  to review live patient-monitoring status.
+- Operating environment: current Windows dashboard flow in live simulation
+  today, with the design remaining compatible with a future live HAL-backed
+  monitoring path.
+- Foreseeable misuse: a user may read the value as time since physiological
+  onset rather than time since the software entered the current abnormal
+  aggregate state.
+- Foreseeable misuse: a user may read the cue as an acknowledgement timer,
+  escalation timer, or muted-alarm timer even though the product implements no
+  such workflow.
+- Foreseeable misuse: if the cue remains visible during paused simulation,
+  cleared session, logout, or non-monitoring mode, a user may assume active
+  monitoring continued when it did not.
+
+## Current behavior
+
+- `patient_current_status()` in `src/patient.c` returns the aggregate severity
+  for the latest reading and intentionally carries no timing metadata.
+- `PatientRecord` in `include/patient.h` stores only patient demographics,
+  `VitalSigns readings[MAX_READINGS]`, and `reading_count`.
+- `VitalSigns` in `include/vitals.h` has no observation timestamp field.
+- `paint_status_banner()` in `src/gui_main.c` uses aggregate severity to choose
+  banner colour during simulation mode, but it currently renders generic
+  simulation/device-mode messaging rather than an elapsed abnormal-state age.
+- `update_dashboard()` rebuilds the alerts and history lists when the dashboard
+  changes, but it does not maintain a separate elapsed-time state.
+- The only current recurring dashboard timer is `TIMER_SIM` at 2000 ms for
+  synthetic data ingestion. There is no dedicated 1 Hz repaint path for a
+  duration cue.
+- Session-clearing and monitoring-state transitions already exist in
+  `gui_main.c` via admit/refresh, clear session, simulation enable/disable,
+  pause/resume, and logout flows. Those are the right reset boundaries for the
+  new cue.
+
+## Proposed change
+
+Implement the feature as a GUI-local abnormal-state timer with explicit reset
+semantics.
+
+1. Add GUI-owned timing state to `AppState` in `src/gui_main.c`.
+   Recommended fields are the currently tracked abnormal aggregate level and the
+   tick count when that same abnormal level became active. This state should
+   exist only in the presentation layer.
+2. Add a small helper in `gui_main.c` that derives the current display state
+   from live dashboard context:
+   - if monitoring is not actively live, clear the duration state
+   - if no patient is active, clear the duration state
+   - if the aggregate level is `ALERT_NORMAL`, clear the duration state
+   - if the aggregate level changes between `WARNING` and `CRITICAL`, restart
+     the timer at zero for the new level
+   - if the aggregate level remains the same abnormal level, retain the
+     original entered-state timestamp
+3. Use wall-clock or monotonic GUI tick time such as `GetTickCount64()` to
+   compute elapsed time. Do not derive elapsed time from `reading_count`, the
+   simulation sample cadence, or historical-record backfill.
+4. Render the cue adjacent to the aggregate status surface in or immediately
+   beside `paint_status_banner()`. The implementation should keep severity as
+   the primary cue and render duration as secondary text or a subordinate badge.
+   It should not overload the header role pill.
+5. Preserve current mode-state clarity. If the existing simulation/device-mode
+   wording needs to move or shrink to make room, it may do so, but the final UI
+   must still communicate whether monitoring is live, paused, or unavailable.
+6. Add a dedicated repaint cadence for the duration display while the cue is
+   visible. A 1 Hz UI timer is preferred so the displayed value matches real
+   elapsed time rather than stepping only on new synthetic readings.
+7. Use a bounded, unambiguous duration format such as `MM:SS`, with optional
+   promotion to `HH:MM:SS` for longer runs if layout allows. The wording must
+   make clear that the timer is "time in current alert state", not onset time.
+8. Route any new connective text or templates through the existing localization
+   layer rather than hard-coding English UI strings in `gui_main.c`.
+9. Reset or clear the cue on all of the following:
+   - `WARNING` to `CRITICAL`
+   - `CRITICAL` to `WARNING`
+   - abnormal state to `NORMAL`
+   - clear session
+   - admit/refresh into a new monitoring session
+   - logout or dashboard teardown
+   - simulation pause
+   - simulation disable / device mode / other non-monitoring state
+10. Keep the implementation local to the dashboard presentation path. If
+    implementation discovers a need for persisted timestamps, patient-history
+    replay, or acknowledgement workflow, stop and split that work into a new
+    issue.
+
+## Files expected to change
+
+Expected implementation files:
+
+- `src/gui_main.c`
+- `include/localization.h`
+- `src/localization.c`
+
+Expected requirements and evidence files:
+
+- `requirements/SYS.md`
+- `requirements/SWR.md`
+- `requirements/TRACEABILITY.md`
+
+Expected files to inspect but likely not modify:
+
+- `docs/history/risk/65-show-current-alert-duration-beside-the-status-pill.md`
+- `docs/ARCHITECTURE.md`
+- `README.md`
+
+Optional files only if the implementer extracts a pure formatting/helper unit
+for testability:
+
+- `tests/CMakeLists.txt`
+- a new narrow unit test file for duration-format or reset-state helper logic
+
+Files that should not change for this issue:
+
+- `src/patient.c`
+- `src/vitals.c`
+- `src/alerts.c`
+- `src/news2.c`
+- `include/patient.h`
+- `include/vitals.h`
+- persistence, authentication, CI, and release workflow files
+
+## Requirements and traceability impact
+
+This issue should remain traceable as a dashboard-display enhancement, not a
+clinical logic change.
+
+Recommended requirement updates:
+
+- Update `SYS-014` to state that the graphical dashboard may display elapsed
+  time for the current abnormal aggregate alert state during active monitoring.
+- Keep `SYS-006` unchanged because aggregate severity logic is not changing.
+- Keep `SYS-011` unchanged unless the team explicitly decides to add the same
+  cue to the CLI patient summary. That is out of scope for issue #65.
+- Keep `SWR-PAT-004` unchanged because `patient_current_status()` remains the
+  source of truth for severity only.
+- Either extend `SWR-GUI-003` with the duration-display semantics or, more
+  cleanly, add a new GUI-level requirement dedicated to abnormal-state elapsed
+  time and reset behavior. A separate `SWR-GUI-013` is preferred because the
+  reset semantics are specific and testable.
+
+Recommended traceability outcome if a new SWR is added:
+
+- map the new GUI duration requirement to `src/gui_main.c`
+- verify via GUI demonstration or targeted helper-unit tests plus manual GUI
+  review
+- avoid adding any trace rows that imply changes to `patient.c`, `vitals.c`,
+  `alerts.c`, or NEWS2 behavior
+
+## Medical-safety, security, and privacy impact
+
+Medical-safety impact is low to moderate and driven by interpretation, not by
+classification logic. The cue can influence triage urgency, so the design must
+ensure that severity remains primary and duration semantics remain narrow:
+"time since the software entered the current abnormal aggregate state."
+
+The main controls are:
+
+- derive the timer from aggregate-state transitions only
+- clear it whenever monitoring is not actively live
+- do not display it for `NORMAL`
+- keep it visually subordinate to severity colour, severity text, and raw vital
+  values
+
+Security impact is low. The change does not introduce new privileges, storage,
+network paths, or credential flows. The only meaningful integrity concern is
+that the displayed duration must not be stale or misleading.
+
+Privacy impact is none expected. No new patient-data class, export path, log,
+or persistence mechanism is introduced.
+
+## AI/ML impact assessment
+
+This change does not add, change, remove, or depend on an AI-enabled device
+software function.
+
+- Model purpose: none
+- Model inputs: none
+- Model outputs: none
+- Human-in-the-loop limits: unchanged
+- Transparency needs: unchanged beyond ordinary UI wording clarity
+- Dataset and bias considerations: none
+- Monitoring expectations: none beyond ordinary GUI verification
+- PCCP impact: none
+
+## Validation plan
+
+Primary design-validation expectations:
+
+- Verify `NORMAL -> WARNING` starts the timer at the first abnormal aggregate
+  state.
+- Verify `WARNING -> CRITICAL` resets the displayed duration to the new
+  critical-state entry time.
+- Verify `CRITICAL -> WARNING` resets the displayed duration to the new warning
+  state rather than carrying forward critical age.
+- Verify abnormal `-> NORMAL` clears the cue completely.
+- Verify the timer does not reset while the aggregate level remains unchanged
+  across multiple live updates.
+- Verify pause, clear session, admit/refresh, logout, and simulation disable
+  clear the cue and prevent stale carryover into the next session.
+- Verify the cue is absent in device/non-monitoring mode and does not imply
+  live monitoring when the system is paused or inactive.
+- Verify the final layout keeps severity visually primary and does not obscure
+  the existing banner or header controls.
+
+Recommended verification commands during implementation:
+
+```powershell
+run_tests.bat
+ctest --test-dir build --output-on-failure -R Patient|Alert|GUI
+git diff --stat
+rg -n "SYS-014|SWR-GUI-003|SWR-GUI-013|65-show-current-alert-duration" requirements docs/history
+```
+
+Manual GUI scenarios should include at minimum:
+
+- steady `WARNING`
+- steady `CRITICAL`
+- `WARNING -> CRITICAL`
+- `CRITICAL -> WARNING`
+- abnormal `-> NORMAL`
+- pause and resume
+- clear session and re-admit
+- simulation disable / device mode transition
+
+## Rollback or failure handling
+
+If implementation cannot satisfy the feature without adding timestamps to
+`VitalSigns` or `PatientRecord`, stop and split that work into a separate
+issue. That would exceed the intended presentation-only scope.
+
+If implementation requires acknowledgement workflow, historical alarm review,
+cross-session continuity, or new persistence, stop and split the scope instead
+of broadening issue #65 silently.
+
+If layout constraints make the cue visually dominate severity or conflict with
+live/paused/device-mode messaging, prefer a smaller secondary presentation or
+hide the cue outside live abnormal monitoring rather than forcing a larger UI
+refactor.
+
+If requirement updates drift toward rewriting aggregate-alert logic rather than
+describing display semantics, revert that expansion and keep the change scoped
+to dashboard presentation behavior.

--- a/dvt/DVT_Protocol.md
+++ b/dvt/DVT_Protocol.md
@@ -124,7 +124,7 @@ layout behavior, or animated presentation rather than stable control state.
 |---|---|
 | Unit test pass rate | 100% (`293 / 293`) |
 | Integration test pass rate | 100% (`14 / 14`) |
-| Automated GTest total | 100% (`307 / 307`) |
+| Automated GTest total | 100% (`317 / 317`) |
 | Automated GUI checks for approved IDs | All executed approved-ID checks pass |
 | Manual GUI checklist | All applicable manual items marked Pass |
 

--- a/dvt/run_dvt.py
+++ b/dvt/run_dvt.py
@@ -112,6 +112,7 @@ REQUIREMENT_MAP = {
     "SWR-GUI-011": (None, "MANUAL", "Rolling simulation banner verified by manual visual check"),
     "SWR-GUI-012": ("test_unit", "LocalizationTest", "Localization API, selector list, and monitor.cfg persistence"),
     "SWR-GUI-013": (None, "MANUAL", "GUI review: dedicated session alarm events list remains distinct from active alerts"),
+    "SWR-GUI-014": ("test_unit", "StatusDuration", "Current alert-state duration helper and banner timing support"),
     # GUI requirements verified via manual checklist only (GUI rendering and workflow review)
     "SWR-GUI-001": (None, "MANUAL", "Login screen: auth, error message, role detection"),
     "SWR-GUI-002": (None, "MANUAL", "Dashboard: colour-coded vital tiles update every 2 s"),

--- a/include/gui_status_duration.h
+++ b/include/gui_status_duration.h
@@ -1,0 +1,34 @@
+#ifndef GUI_STATUS_DURATION_H
+#define GUI_STATUS_DURATION_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "vitals.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    AlertLevel tracked_level;
+    uint64_t   entered_ms;
+    int        active;
+} GuiStatusDurationState;
+
+void gui_status_duration_reset(GuiStatusDurationState *state);
+void gui_status_duration_update(GuiStatusDurationState *state,
+                                int monitoring_live,
+                                int has_patient,
+                                AlertLevel current_level,
+                                uint64_t now_ms);
+int gui_status_duration_is_active(const GuiStatusDurationState *state);
+uint64_t gui_status_duration_elapsed_seconds(const GuiStatusDurationState *state,
+                                             uint64_t now_ms);
+int gui_status_duration_format(uint64_t elapsed_seconds, char *out, size_t out_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GUI_STATUS_DURATION_H */

--- a/include/localization.h
+++ b/include/localization.h
@@ -106,6 +106,8 @@ typedef enum {
     STR_STATUS_CRITICAL,
     STR_DEVICE_MODE_MSG,
     STR_SIM_MODE_MSG,
+    STR_SIM_PAUSED_MSG,
+    STR_ALERT_STATE_AGE,
 
     STR_COUNT  /* Total number of strings */
 } StringID;

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -118,7 +118,7 @@ Before submitting for regulatory review, verify:
 - [ ] All requirement annotations in code comments refer to valid SWR IDs in `SWR.md`
 - [ ] All Google Test names follow the `REQ_XXX_NNN_Description` pattern
 - [ ] `docs/doxygen_warnings.log` is empty (no undocumented or malformed comments)
-- [ ] All 307 tests pass (`run_tests.bat`)
+- [ ] All 317 tests pass (`run_tests.bat`)
 - [ ] `AuthValidation.*` and `AuthDisplayName.*` (15 tests) all pass
 - [ ] Line coverage ≥ 99% for `vitals.c`, `alerts.c`, `patient.c` (`run_coverage.bat`)
 - [ ] No dynamic memory allocation in production code

--- a/requirements/SWR.md
+++ b/requirements/SWR.md
@@ -1,6 +1,6 @@
 # Software Requirements Specification (SWR)
 
-**Document ID:** SWR-001-REV-M
+**Document ID:** SWR-001-REV-N
 **Project:** Patient Vital Signs Monitor
 **Version:** 2.7.0
 **Date:** 2026-05-06
@@ -717,6 +717,39 @@ session event label string
 
 ---
 
+### SWR-GUI-014 â€” Current Alert-State Duration Cue
+
+**Requirement:** While active monitoring is live (`sim_enabled = 1` and
+`sim_paused = 0`), the aggregate status banner shall display a secondary
+elapsed-time cue for the current abnormal aggregate alert state:
+
+1. The cue shall be driven only by the aggregate `patient_current_status()`
+   result and shall appear only for `ALERT_WARNING` and `ALERT_CRITICAL`.
+2. The timer shall start when the software enters the current abnormal
+   aggregate state and shall continue while that same abnormal level remains
+   unchanged.
+3. The timer shall reset or clear on any of the following:
+   - `ALERT_WARNING` to `ALERT_CRITICAL`
+   - `ALERT_CRITICAL` to `ALERT_WARNING`
+   - abnormal state to `ALERT_NORMAL`
+   - simulation pause or device-mode transition
+   - clear session, admit/refresh, automatic session reset, or logout
+4. The cue shall refresh at least once per second while visible and shall use
+   the format `MM:SS`, promoting to `HH:MM:SS` after one hour.
+5. The cue shall remain visually subordinate to the existing aggregate
+   severity text and colour and shall not claim physiological onset time,
+   acknowledgement age, or escalation workflow.
+
+**Traces to:** SYS-014
+**Implemented in:** `src/gui_status_duration.c` â€” abnormal-state timing and
+formatting; `src/gui_main.c` â€” banner rendering, reset hooks, 1 Hz timer;
+`src/localization.c` â€” duration and paused-status banner strings
+**Verified by:** `tests/unit/test_gui_status_duration.cpp` â€” `StatusDuration.*`
+(10 tests) plus manual GUI review of abnormal transitions, pause, clear,
+admit/refresh, and logout behavior
+
+---
+
 ## Revision History
 
 | Rev | Date       | Author          | Description          |
@@ -734,3 +767,4 @@ session event label string
 | K   | 2026-05-05 | Codex implementer | Restored defensible SYS-level traceability for SWR-VIT-008 and SWR-NEW-001; no clinical behavior changes |
 | L   | 2026-05-05 | Codex implementer | Added SWR-PAT-007/008 and SWR-GUI-013 for session alarm event review |
 | M   | 2026-05-06 | Codex implementer | Added explicit session-reset disclosure expectations for session review surfaces |
+| N   | 2026-05-06 | Codex implementer | Added SWR-GUI-014 for current alert-state duration display, reset semantics, and 1 Hz refresh behavior |

--- a/requirements/SYS.md
+++ b/requirements/SYS.md
@@ -1,9 +1,9 @@
 # System Requirements Specification (SYS)
 
-**Document ID:** SYS-001-REV-F
+**Document ID:** SYS-001-REV-G
 **Project:** Patient Vital Signs Monitor
 **Version:** 1.0.0
-**Date:** 2026-05-05
+**Date:** 2026-05-06
 **Status:** Approved
 **Standard:** 21 CFR 820.30(d) / IEC 62304 §5.1
 
@@ -163,6 +163,11 @@ active patient in a graphical dashboard using colour-coded status tiles:
 green for NORMAL, amber for WARNING, and red for CRITICAL. The aggregate
 alert status shall be displayed in a banner using the same colour convention.
 The dashboard shall refresh automatically after each new reading is added.
+During active monitoring, when the aggregate alert status is `WARNING` or
+`CRITICAL`, the dashboard may display elapsed time for the current abnormal
+aggregate alert state. That elapsed-time cue shall reset whenever the
+aggregate alert level changes, monitoring pauses, the session is cleared or
+re-admitted, the user logs out, or the system leaves active monitoring.
 **Traces to:** UNS-014, UNS-005, UNS-006, UNS-010
 
 ---
@@ -266,3 +271,4 @@ events have been recorded.
 | D   | 2026-04-07 | vinu-engineer   | Added SYS-016 (multi-user accounts), SYS-017 (RBAC) |
 | E   | 2026-05-05 | Codex implementer | Added SYS-018 (RR) and SYS-019 (NEWS2) to restore defensible traceability for existing clinical requirements |
 | F   | 2026-05-05 | Codex implementer | Added SYS-020 and SYS-021 for session alarm event review |
+| G   | 2026-05-06 | Codex implementer | Extended SYS-014 with alert-state duration display and reset semantics for active monitoring |

--- a/requirements/TRACEABILITY.md
+++ b/requirements/TRACEABILITY.md
@@ -1,6 +1,6 @@
 # Requirements Traceability Matrix (RTM)
 
-**Document ID:** RTM-001-REV-L
+**Document ID:** RTM-001-REV-M
 **Project:** Patient Vital Signs Monitor
 **Version:** 2.7.0
 **Date:** 2026-05-06
@@ -48,6 +48,7 @@ implementation and test coverage, and every UNS must reach at least one SWR.
 | UNS-015 | SYS-015 | SWR-GUI-010 | `gui_main.c`, `app_config.c` : sim toggle + persistence | Manual GUI review + `ConfigTest.*` support (10 persistence checks) | — |
 | UNS-015 | SYS-005 | SWR-GUI-011 | `gui_main.c` : rolling message in sim mode (`paint_status_banner()`, scroll offset) | Manual visual review | — |
 | UNS-014 | SYS-014 | SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : language tab, selector strings, `monitor.cfg` persistence/load | `LocalizationTest.*` (8 tests) + supplemental `DVT-GUI-16` | — |
+| UNS-014 | SYS-014 | SWR-GUI-014 | `gui_status_duration.c` : abnormal-state age tracking + formatting; `gui_main.c` : banner rendering, reset hooks, 1 Hz repaint timer | `StatusDuration.*` (10 tests) + manual GUI review of abnormal transitions/pause/reset | â€” |
 | UNS-005, UNS-006 | SYS-005 | SWR-ALT-001 | `alerts.c` : `generate_alerts()` | `REQ_ALT_002_*` (4 tests) | `REQ_INT_MON_004`, `REQ_INT_ESC_002`, `REQ_INT_ESC_003` |
 | UNS-005 | SYS-005 | SWR-ALT-002 | `alerts.c` : `generate_alerts()` | `REQ_ALT_001_*` (1 test) | `REQ_INT_ESC_004` |
 | UNS-011 | SYS-012 | SWR-ALT-003 | `alerts.c` : `generate_alerts()` | `REQ_ALT_004_*` (2 tests) | — |
@@ -113,6 +114,7 @@ implementation and test coverage, and every UNS must reach at least one SWR.
 | `UsersTest` | `REQ_SEC_004_*` | SWR-SEC-004 | SYS-017 | UNS-016 |
 | `UsersTest` | `REQ_GUI_007_*` | SWR-GUI-007 | SYS-016 | UNS-016 |
 | `LocalizationTest` | `LocalizationTest.*` | SWR-GUI-012 | SYS-014 | UNS-014 |
+| `StatusDuration` | `StatusDuration.*` | SWR-GUI-014 | SYS-014 | UNS-014 |
 | `RespRate` | `REQ_VIT_008_*` | SWR-VIT-008 | SYS-018 | UNS-005, UNS-006, UNS-014, UNS-015 |
 | `News2HR`, `News2RR`, etc. | `News2*.*` | SWR-NEW-001 | SYS-019 | UNS-005, UNS-006, UNS-010, UNS-014 |
 | `AlarmLimitsTest` | `AlarmLimitsTest.*` | SWR-ALM-001 | SYS-002, SYS-003 | UNS-005, UNS-006 |
@@ -161,7 +163,7 @@ Supporting implementation checks:
 | UNS-011 | Data integrity | SYS-010, SYS-012 | SWR-PAT-002, SWR-PAT-005, SWR-ALT-003, SWR-PAT-001 | ✓ |
 | UNS-012 | Platform compatibility | SYS-012 | SWR-PAT-001, SWR-ALT-003 | ✓ |
 | UNS-013 | User authentication | SYS-013 | SWR-GUI-001, SWR-GUI-002 | ✓ |
-| UNS-014 | Graphical dashboard | SYS-014, SYS-018, SYS-019, SYS-021 | SWR-GUI-003, SWR-GUI-004, SWR-GUI-012, SWR-GUI-013, SWR-VIT-008, SWR-NEW-001 | ✓ |
+| UNS-014 | Graphical dashboard | SYS-014, SYS-018, SYS-019, SYS-021 | SWR-GUI-003, SWR-GUI-004, SWR-GUI-012, SWR-GUI-013, SWR-GUI-014, SWR-VIT-008, SWR-NEW-001 | ✓ |
 | UNS-015 | Live monitoring feed | SYS-015, SYS-018 | SWR-GUI-005, SWR-GUI-006, SWR-GUI-010, SWR-GUI-011, SWR-VIT-008 | ✓ |
 | UNS-016 | Role-based access / multi-user | SYS-016, SYS-017 | SWR-SEC-001, SWR-SEC-002, SWR-SEC-003, SWR-GUI-007, SWR-GUI-008, SWR-GUI-009 | ✓ |
 | UNS-017 | Session alarm event review | SYS-020, SYS-021 | SWR-PAT-006, SWR-PAT-007, SWR-PAT-008, SWR-GUI-013 | ✓ |
@@ -212,12 +214,13 @@ Supporting implementation checks:
 | SWR-GUI-011 | `gui_main.c` : `paint_status_banner()`, scroll offset | Manual visual review | — | ✓ |
 | SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : selector strings, persistence/load | `LocalizationTest.*` (8) + supplemental `DVT-GUI-16` | — | ✓ |
 | SWR-GUI-013 | `create_dash_controls()`, `reposition_dash_controls()`, `update_dashboard()` | Manual GUI review (`GUI-MAN-06`) | — | ✓ |
+| SWR-GUI-014 | `gui_status_duration.c`, `gui_main.c`, `localization.c` : alert-state duration tracking, banner rendering, 1 Hz refresh, reset hooks | `StatusDuration.*` (10) + manual GUI review | — | ✓ |
 | SWR-VIT-008 | `vitals.c` : `check_respiration_rate()` | 15 | — | ✓ |
 | SWR-NEW-001 | `news2.c` : `news2_calculate()` | 53 | — | ✓ |
 | SWR-ALM-001 | `alarm_limits.c` : `alarm_limits_defaults()`, `alarm_check_*()` | 31 | — | ✓ |
 | SWR-TRD-001 | `trend.c` : `trend_direction()`, `trend_extract_*()` | 18 | — | ✓ |
 
-**Result: 40 / 40 SWRs implemented and tested ✓**
+**Result: 41 / 41 SWRs implemented and tested ✓**
 
 ---
 
@@ -269,9 +272,10 @@ This is recorded as an accepted coverage exclusion with a documented rationale.
 | `tests/unit/test_hal.cpp` | 12 | Supporting HAL / simulator checks only; no direct SWR verification claim |
 | `tests/unit/test_config.cpp` | 10 | Supporting config persistence checks only; no direct SWR verification claim |
 | `tests/unit/test_localization.cpp` | 8 | SWR-GUI-012 |
+| `tests/unit/test_gui_status_duration.cpp` | 10 | SWR-GUI-014 |
 | `tests/integration/test_patient_monitoring.cpp` | 7 | SWR-PAT-*, SWR-VIT-*, SWR-ALT-* |
 | `tests/integration/test_alert_escalation.cpp` | 7 | SWR-VIT-*, SWR-ALT-*, SWR-PAT-004, SWR-PAT-007 |
-| **Total** | **307** | **40 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
+| **Total** | **317** | **41 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
 
 ---
 
@@ -291,3 +295,4 @@ This is recorded as an accepted coverage exclusion with a documented rationale.
 | J   | 2026-05-05 | Codex implementer | Restored defensible SYS-level traceability for RR and NEWS2 requirements; 37/37 SWR, 295 tests |
 | K   | 2026-05-05 | Codex implementer | Added session alarm event review traceability: UNS-017, SYS-020/021, SWR-PAT-007/008, SWR-GUI-013; 40/40 SWR, 305 tests |
 | L   | 2026-05-06 | Codex implementer | Added session-reset disclosure traceability and updated automated totals to 307 tests |
+| M   | 2026-05-06 | Codex implementer | Added SWR-GUI-014 alert-state duration traceability with 10 automated duration-helper tests; updated totals to 317 tests |

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -3,7 +3,7 @@ setlocal enabledelayedexpansion
 
 echo =====================================================
 echo   Patient Vital Signs Monitor -- Test Runner
-echo   307 tests: Unit (293) + Integration (14)
+echo   317 tests: Unit (303) + Integration (14)
 echo   Standard : IEC 62304 Class B
 echo =====================================================
 echo.
@@ -87,7 +87,7 @@ echo.
 :: Summary and exit code
 :: -------------------------------------------------------
 if !UNIT_RESULT! EQU 0 if !INT_RESULT! EQU 0 (
-    echo [PASS] All 307 tests passed.
+    echo [PASS] All 317 tests passed.
     echo.
     pause
     exit /b 0

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -14,6 +14,7 @@
  * @req SWR-GUI-001  @req SWR-GUI-002  @req SWR-GUI-003  @req SWR-GUI-004
  * @req SWR-SEC-001  @req SWR-SEC-002  @req SWR-SEC-003
  * @req SWR-GUI-007  @req SWR-GUI-008  @req SWR-GUI-009  @req SWR-GUI-010
+ * @req SWR-GUI-014
  * @req SWR-VIT-008  @req SWR-NEW-001
  */
 #ifdef _MSC_VER
@@ -37,6 +38,7 @@
 #include "gui_users.h"
 #include "hw_vitals.h"
 #include "app_config.h"
+#include "gui_status_duration.h"
 #include "localization.h"
 
 /* ===================================================================
@@ -99,6 +101,7 @@
 #define IDC_LIST_HISTORY 1301
 #define IDC_LIST_EVENTS  1302
 #define TIMER_SIM        1
+#define TIMER_ALERT_DURATION 2
 
 /* ===================================================================
  * Control IDs — Settings window
@@ -207,6 +210,7 @@ typedef struct {
     int           sim_paused;
     int           sim_enabled;  /**< 1=simulation mode, 0=device/HAL mode @req SWR-GUI-010 */
     int           sim_msg_scroll_offset; /**< Offset for rolling message in simulation mode */
+    GuiStatusDurationState alert_duration; /**< Aggregate abnormal-state age @req SWR-GUI-014 */
     AlarmLimits   alarm_limits; /**< Configurable per-parameter alarm limits @req SWR-ALM-001 */
 
     HFONT font_hdr;
@@ -240,6 +244,8 @@ static void apply_sim_mode(HWND dash);
 static void open_settings(HWND parent);
 static void open_pwddlg(HWND parent, const char *user, int admin_mode);
 static void open_adduser(HWND parent);
+static void stop_alert_duration(HWND w);
+static void refresh_alert_duration(HWND w);
 
 /* ===================================================================
  * GDI helpers
@@ -534,18 +540,95 @@ static void paint_tiles(HDC hdc, int cw)
 
 static void paint_status_banner(HDC hdc, int cw)
 {
-    COLORREF bg, fg; const char *txt;
+    AlertLevel banner_lvl = g_app.has_patient ? patient_current_status(&g_app.patient) : ALERT_NORMAL;
+    COLORREF bg, fg;
+    const char *status_txt;
+    const char *mode_txt;
+    char duration_value[16];
+    char duration_txt[96];
     char rolling_msg[256];
     int offset;
+    RECT r;
 
     if (!g_app.sim_enabled) {
         bg  = CLR_SLATE;
         fg  = CLR_LIGHT_GRAY;
-        txt = localization_get_string(STR_DEVICE_MODE_MSG);
+        status_txt = localization_get_string(STR_DEVICE_MODE_MSG);
         fill_rect(hdc, 0, STAT_Y, cw, STAT_H, bg);
-        draw_text_ex(hdc, txt, 0, STAT_Y, cw, STAT_H,
+        draw_text_ex(hdc, status_txt, 0, STAT_Y, cw, STAT_H,
                      g_app.font_status, fg, DT_SINGLELINE|DT_VCENTER|DT_CENTER);
+        return;
     } else {
+        switch (banner_lvl) {
+            case ALERT_CRITICAL:
+                bg = CLR_CR_FG;
+                fg = CLR_WHITE;
+                status_txt = localization_get_string(STR_STATUS_CRITICAL);
+                break;
+            case ALERT_WARNING:
+                bg = CLR_WN_FG;
+                fg = CLR_WHITE;
+                status_txt = localization_get_string(STR_STATUS_WARNING);
+                break;
+            default:
+                bg = CLR_OK_FG;
+                fg = CLR_WHITE;
+                status_txt = localization_get_string(STR_STATUS_NORMAL);
+                break;
+        }
+
+        fill_rect(hdc, 0, STAT_Y, cw, STAT_H, bg);
+
+        duration_txt[0] = '\0';
+        if (gui_status_duration_is_active(&g_app.alert_duration)) {
+            uint64_t elapsed_seconds =
+                gui_status_duration_elapsed_seconds(&g_app.alert_duration, (uint64_t)GetTickCount64());
+            if (gui_status_duration_format(elapsed_seconds, duration_value, sizeof(duration_value))) {
+                snprintf(duration_txt, sizeof(duration_txt), "%s: %s",
+                         localization_get_string(STR_ALERT_STATE_AGE), duration_value);
+            }
+        }
+
+        draw_text_ex(hdc, status_txt,
+                     16, STAT_Y + 2,
+                     duration_txt[0] != '\0' ? cw - 252 : cw - 32,
+                     18,
+                     g_app.font_status, fg,
+                     duration_txt[0] != '\0'
+                         ? DT_SINGLELINE | DT_VCENTER | DT_LEFT
+                         : DT_SINGLELINE | DT_VCENTER | DT_CENTER);
+
+        if (duration_txt[0] != '\0') {
+            draw_text_ex(hdc, duration_txt,
+                         cw - 236, STAT_Y + 2, 220, 18,
+                         g_app.font_tile_lbl, fg,
+                         DT_SINGLELINE | DT_VCENTER | DT_RIGHT);
+        }
+
+        if (g_app.sim_paused) {
+            mode_txt = localization_get_string(STR_SIM_PAUSED_MSG);
+            draw_text_ex(hdc, mode_txt,
+                         16, STAT_Y + 22, cw - 32, 18,
+                         g_app.font_tile_lbl, fg,
+                         DT_SINGLELINE | DT_VCENTER | DT_CENTER);
+            return;
+        }
+
+        offset = g_app.sim_msg_scroll_offset;
+        mode_txt = localization_get_string(STR_SIM_MODE_MSG);
+        snprintf(rolling_msg, sizeof(rolling_msg),
+                 "   âœ¦  %s  âœ¦   %s  âœ¦   %s  âœ¦   %s  âœ¦",
+                 mode_txt, mode_txt, mode_txt, mode_txt);
+        r.left   = -offset;
+        r.top    = STAT_Y + 22;
+        r.right  = cw + 500;
+        r.bottom = STAT_Y + STAT_H;
+        SetTextColor(hdc, fg);
+        SetBkMode(hdc, TRANSPARENT);
+        SelectObject(hdc, g_app.font_tile_lbl);
+        DrawTextA(hdc, rolling_msg, -1, &r, DT_SINGLELINE|DT_VCENTER|DT_LEFT);
+        return;
+
         /* In simulation mode, show rolling message */
         offset = g_app.sim_msg_scroll_offset;
 
@@ -695,6 +778,7 @@ static void update_dashboard(HWND w)
     SendMessageA(GetDlgItem(w,IDC_LIST_HISTORY),LB_RESETCONTENT,0,0);
     SendMessageA(GetDlgItem(w,IDC_LIST_ALERTS), LB_RESETCONTENT,0,0);
     SendMessageA(GetDlgItem(w,IDC_LIST_EVENTS), LB_RESETCONTENT,0,0);
+    refresh_alert_duration(w);
     InvalidateRect(w, NULL, FALSE);
 
     if (!g_app.has_patient) {
@@ -804,6 +888,7 @@ static int do_admit(HWND w)
         SetFocus(GetDlgItem(w,IDC_PAT_NAME)); return 0;
     }
     patient_init(&g_app.patient,id,name,age,wt,ht);
+    gui_status_duration_reset(&g_app.alert_duration);
     g_app.has_patient=1;
     update_dashboard(w); return 1;
 }
@@ -826,6 +911,7 @@ static void do_add_reading(HWND w)
 static void do_clear(HWND w)
 {
     ZeroMemory(&g_app.patient,sizeof(g_app.patient));
+    gui_status_duration_reset(&g_app.alert_duration);
     g_app.has_patient=0;
     set_txt(w,IDC_PAT_ID,    "1001"); set_txt(w,IDC_PAT_NAME,"Sarah Johnson");
     set_txt(w,IDC_PAT_AGE,   "52");   set_txt(w,IDC_PAT_WEIGHT,"72.5");
@@ -1618,6 +1704,7 @@ static void apply_sim_mode(HWND dash)
         VitalSigns sv;
         if (!g_app.has_patient) {
             patient_init(&g_app.patient, 2001, "James Mitchell", 45, 78.0f, 1.75f);
+            gui_status_duration_reset(&g_app.alert_duration);
             g_app.has_patient = 1;
             set_txt(dash,IDC_PAT_ID,"2001"); set_txt(dash,IDC_PAT_NAME,"James Mitchell");
             set_txt(dash,IDC_PAT_AGE,"45");  set_txt(dash,IDC_PAT_WEIGHT,"78.0");
@@ -1630,6 +1717,7 @@ static void apply_sim_mode(HWND dash)
         SetTimer(dash, TIMER_SIM, 2000, NULL);
     } else {
         KillTimer(dash, TIMER_SIM);
+        stop_alert_duration(dash);
         g_app.sim_paused = 0;
         ZeroMemory(&g_app.patient, sizeof(g_app.patient));
         g_app.has_patient = 0;
@@ -1740,6 +1828,7 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
         alarm_limits_load(&g_app.alarm_limits);       /* restore alarm limits @req SWR-ALM-001 */
         hw_init();
         g_app.sim_paused = 0;
+        gui_status_duration_reset(&g_app.alert_duration);
 
         /* Pause Sim and demo buttons only visible when simulation is active */
         ShowWindow(GetDlgItem(w, IDC_BTN_PAUSE), g_app.sim_enabled ? SW_SHOW : SW_HIDE);
@@ -1781,6 +1870,11 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
     }
 
     case WM_TIMER:
+        if (wp == TIMER_ALERT_DURATION) {
+            refresh_alert_duration(w);
+            InvalidateRect(w, NULL, FALSE);
+            return 0;
+        }
         if (wp == TIMER_SIM && g_app.sim_enabled && !g_app.sim_paused) {
             VitalSigns v;
             if (g_app.has_patient && patient_is_full(&g_app.patient)) {
@@ -1790,6 +1884,7 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
                              g_app.patient.info.age, g_app.patient.info.weight_kg,
                              g_app.patient.info.height_m);
                 patient_note_session_reset(&g_app.patient, previous_reading_count);
+                gui_status_duration_reset(&g_app.alert_duration);
             }
             hw_get_next_reading(&v);
             patient_add_reading(&g_app.patient, &v);
@@ -1833,13 +1928,17 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             g_app.sim_paused = !g_app.sim_paused;
             SetWindowTextA(GetDlgItem(w,IDC_BTN_PAUSE),
                            g_app.sim_paused ? localization_get_string(STR_RESUME_SIM) : localization_get_string(STR_PAUSE_SIM));
-            InvalidateRect(w, NULL, FALSE);
+            if (g_app.sim_paused) {
+                stop_alert_duration(w);
+            }
+            update_dashboard(w);
             return 0;
         case IDC_BTN_SETTINGS:
             open_settings(w);
             return 0;
         case IDC_BTN_LOGOUT:
             KillTimer(w, TIMER_SIM);
+            stop_alert_duration(w);
             app_config_save(g_app.sim_enabled);
             ZeroMemory(&g_app.patient, sizeof(g_app.patient));
             g_app.has_patient    = 0;
@@ -1859,11 +1958,41 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
 
     case WM_DESTROY:
         KillTimer(w, TIMER_SIM);
+        KillTimer(w, TIMER_ALERT_DURATION);
+        gui_status_duration_reset(&g_app.alert_duration);
         g_app.hwnd_dash = NULL;
         if (g_app.hwnd_login == NULL) PostQuitMessage(0);
         return 0;
     }
     return DefWindowProcA(w, msg, wp, lp);
+}
+
+static int dashboard_monitoring_live(void)
+{
+    return g_app.sim_enabled && !g_app.sim_paused;
+}
+
+static void stop_alert_duration(HWND w)
+{
+    gui_status_duration_reset(&g_app.alert_duration);
+    KillTimer(w, TIMER_ALERT_DURATION);
+}
+
+static void refresh_alert_duration(HWND w)
+{
+    AlertLevel lvl = g_app.has_patient ? patient_current_status(&g_app.patient) : ALERT_NORMAL;
+
+    gui_status_duration_update(&g_app.alert_duration,
+                               dashboard_monitoring_live(),
+                               g_app.has_patient,
+                               lvl,
+                               (uint64_t)GetTickCount64());
+
+    if (gui_status_duration_is_active(&g_app.alert_duration)) {
+        SetTimer(w, TIMER_ALERT_DURATION, 1000, NULL);
+    } else {
+        KillTimer(w, TIMER_ALERT_DURATION);
+    }
 }
 
 /* ===================================================================

--- a/src/gui_status_duration.c
+++ b/src/gui_status_duration.c
@@ -1,0 +1,72 @@
+#include "gui_status_duration.h"
+
+#include <stdio.h>
+
+void gui_status_duration_reset(GuiStatusDurationState *state)
+{
+    if (state == NULL) return;
+
+    state->tracked_level = ALERT_NORMAL;
+    state->entered_ms    = 0;
+    state->active        = 0;
+}
+
+void gui_status_duration_update(GuiStatusDurationState *state,
+                                int monitoring_live,
+                                int has_patient,
+                                AlertLevel current_level,
+                                uint64_t now_ms)
+{
+    if (state == NULL) return;
+
+    if (!monitoring_live || !has_patient || current_level == ALERT_NORMAL) {
+        gui_status_duration_reset(state);
+        return;
+    }
+
+    if (!state->active || state->tracked_level != current_level || now_ms < state->entered_ms) {
+        state->tracked_level = current_level;
+        state->entered_ms    = now_ms;
+        state->active        = 1;
+    }
+}
+
+int gui_status_duration_is_active(const GuiStatusDurationState *state)
+{
+    return state != NULL && state->active;
+}
+
+uint64_t gui_status_duration_elapsed_seconds(const GuiStatusDurationState *state,
+                                             uint64_t now_ms)
+{
+    if (!gui_status_duration_is_active(state) || now_ms < state->entered_ms) {
+        return 0;
+    }
+
+    return (now_ms - state->entered_ms) / 1000ULL;
+}
+
+int gui_status_duration_format(uint64_t elapsed_seconds, char *out, size_t out_len)
+{
+    unsigned long long hours;
+    unsigned long long minutes;
+    unsigned long long seconds;
+    int written;
+
+    if (out == NULL || out_len == 0) return 0;
+
+    hours   = elapsed_seconds / 3600ULL;
+    minutes = (elapsed_seconds % 3600ULL) / 60ULL;
+    seconds = elapsed_seconds % 60ULL;
+
+    if (hours > 0ULL) {
+        written = snprintf(out, out_len, "%02llu:%02llu:%02llu",
+                           hours, minutes, seconds);
+    } else {
+        unsigned long long total_minutes = elapsed_seconds / 60ULL;
+        written = snprintf(out, out_len, "%02llu:%02llu",
+                           total_minutes, seconds);
+    }
+
+    return written > 0 && (size_t)written < out_len;
+}

--- a/src/localization.c
+++ b/src/localization.c
@@ -89,6 +89,8 @@ static const char* g_strings_english[STR_COUNT] = {
     "!! CRITICAL — Immediate clinical action required !!",  /* STR_STATUS_CRITICAL */
     "DEVICE MODE — Enable simulation in Settings to use synthetic data",  /* STR_DEVICE_MODE_MSG */
     "SIMULATION MODE — Synthetic vital data",           /* STR_SIM_MODE_MSG */
+    "SIMULATION PAUSED - Monitoring feed held",          /* STR_SIM_PAUSED_MSG */
+    "Alert state age",                                   /* STR_ALERT_STATE_AGE */
 };
 
 /* Spanish strings */
@@ -162,6 +164,8 @@ static const char* g_strings_spanish[STR_COUNT] = {
     "!! CRÍTICO — Se requiere acción clínica inmediata !!",
     "MODO DISPOSITIVO — Habilite la simulación en Configuración",
     "MODO SIMULACIÓN — Datos vitales sintéticos",
+    "SIMULACION EN PAUSA - Flujo de monitorizacion retenido",
+    "Tiempo en el estado de alerta",
 };
 
 /* French strings */
@@ -235,6 +239,8 @@ static const char* g_strings_french[STR_COUNT] = {
     "!! CRITIQUE — Action clinique immédiate requise !!",
     "MODE APPAREIL — Activez la simulation dans les paramètres",
     "MODE SIMULATION — Données vitales synthétiques",
+    "SIMULATION EN PAUSE - Flux de surveillance suspendu",
+    "Duree de l'etat d'alerte",
 };
 
 /* German strings */
@@ -308,6 +314,8 @@ static const char* g_strings_german[STR_COUNT] = {
     "!! KRITISCH — Sofortige klinische Maßnahme erforderlich !!",
     "GERÄT-MODUS — Aktivieren Sie die Simulation in den Einstellungen",
     "SIMULATIONSMODUS — Synthetische Vitaldaten",
+    "SIMULATION PAUSIERT - Monitoring-Datenstrom angehalten",
+    "Dauer des Alarmzustands",
 };
 
 /* All language tables */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(test_unit
     unit/test_auth.cpp
     unit/test_hal.cpp
     unit/test_config.cpp
+    unit/test_gui_status_duration.cpp
     unit/test_localization.cpp
     unit/test_news2.cpp
     unit/test_alarm_limits.cpp

--- a/tests/unit/test_gui_status_duration.cpp
+++ b/tests/unit/test_gui_status_duration.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "gui_status_duration.h"
+}
+
+TEST(StatusDuration, ResetClearsActiveState)
+{
+    GuiStatusDurationState state = {ALERT_CRITICAL, 15000, 1};
+
+    gui_status_duration_reset(&state);
+
+    EXPECT_FALSE(gui_status_duration_is_active(&state));
+    EXPECT_EQ(ALERT_NORMAL, state.tracked_level);
+    EXPECT_EQ(0ULL, state.entered_ms);
+}
+
+TEST(StatusDuration, StartsAtZeroOnFirstAbnormalState)
+{
+    GuiStatusDurationState state = {ALERT_NORMAL, 0, 0};
+
+    gui_status_duration_update(&state, 1, 1, ALERT_WARNING, 5000);
+
+    EXPECT_TRUE(gui_status_duration_is_active(&state));
+    EXPECT_EQ(ALERT_WARNING, state.tracked_level);
+    EXPECT_EQ(0ULL, gui_status_duration_elapsed_seconds(&state, 5000));
+}
+
+TEST(StatusDuration, KeepsOriginalStartWhileLevelIsUnchanged)
+{
+    GuiStatusDurationState state = {ALERT_NORMAL, 0, 0};
+
+    gui_status_duration_update(&state, 1, 1, ALERT_WARNING, 5000);
+    gui_status_duration_update(&state, 1, 1, ALERT_WARNING, 65000);
+
+    EXPECT_EQ(ALERT_WARNING, state.tracked_level);
+    EXPECT_EQ(5000ULL, state.entered_ms);
+    EXPECT_EQ(60ULL, gui_status_duration_elapsed_seconds(&state, 65000));
+}
+
+TEST(StatusDuration, ResetsWhenSeverityEscalates)
+{
+    GuiStatusDurationState state = {ALERT_NORMAL, 0, 0};
+
+    gui_status_duration_update(&state, 1, 1, ALERT_WARNING, 1000);
+    gui_status_duration_update(&state, 1, 1, ALERT_CRITICAL, 7000);
+
+    EXPECT_EQ(ALERT_CRITICAL, state.tracked_level);
+    EXPECT_EQ(7000ULL, state.entered_ms);
+    EXPECT_EQ(0ULL, gui_status_duration_elapsed_seconds(&state, 7000));
+}
+
+TEST(StatusDuration, ResetsWhenSeverityDeescalates)
+{
+    GuiStatusDurationState state = {ALERT_NORMAL, 0, 0};
+
+    gui_status_duration_update(&state, 1, 1, ALERT_CRITICAL, 2000);
+    gui_status_duration_update(&state, 1, 1, ALERT_WARNING, 11000);
+
+    EXPECT_EQ(ALERT_WARNING, state.tracked_level);
+    EXPECT_EQ(11000ULL, state.entered_ms);
+    EXPECT_EQ(0ULL, gui_status_duration_elapsed_seconds(&state, 11000));
+}
+
+TEST(StatusDuration, ClearsWhenAggregateStatusReturnsNormal)
+{
+    GuiStatusDurationState state = {ALERT_NORMAL, 0, 0};
+
+    gui_status_duration_update(&state, 1, 1, ALERT_WARNING, 1000);
+    gui_status_duration_update(&state, 1, 1, ALERT_NORMAL, 9000);
+
+    EXPECT_FALSE(gui_status_duration_is_active(&state));
+}
+
+TEST(StatusDuration, ClearsWhenMonitoringStops)
+{
+    GuiStatusDurationState state = {ALERT_NORMAL, 0, 0};
+
+    gui_status_duration_update(&state, 1, 1, ALERT_CRITICAL, 1000);
+    gui_status_duration_update(&state, 0, 1, ALERT_CRITICAL, 9000);
+
+    EXPECT_FALSE(gui_status_duration_is_active(&state));
+}
+
+TEST(StatusDuration, ClearsWhenPatientSessionIsMissing)
+{
+    GuiStatusDurationState state = {ALERT_NORMAL, 0, 0};
+
+    gui_status_duration_update(&state, 1, 1, ALERT_WARNING, 1000);
+    gui_status_duration_update(&state, 1, 0, ALERT_WARNING, 9000);
+
+    EXPECT_FALSE(gui_status_duration_is_active(&state));
+}
+
+TEST(StatusDuration, FormatsMinutesAndSecondsBelowOneHour)
+{
+    char formatted[16] = {0};
+
+    ASSERT_TRUE(gui_status_duration_format(135ULL, formatted, sizeof(formatted)));
+    EXPECT_STREQ("02:15", formatted);
+}
+
+TEST(StatusDuration, FormatsHoursMinutesAndSecondsAfterOneHour)
+{
+    char formatted[16] = {0};
+
+    ASSERT_TRUE(gui_status_duration_format(3723ULL, formatted, sizeof(formatted)));
+    EXPECT_STREQ("01:02:03", formatted);
+}


### PR DESCRIPTION
Closes #65

## Spec Path
- `docs/history/specs/65-show-current-alert-duration-beside-the-status-pill.md`

## Summary
- show the current abnormal aggregate alert-state age in the dashboard banner
- reset the duration on severity changes, pause, session resets, logout, and other non-monitoring states
- add a focused duration helper, localized banner text, and supporting requirements/traceability updates

## Requirements And Traceability Impact
- extend `SYS-014` dashboard behavior to cover the current abnormal-state age cue
- add `SWR-GUI-014` for alert-state duration tracking, rendering, and reset behavior
- update `requirements/TRACEABILITY.md`, `dvt/run_dvt.py`, and related evidence counts to 41 SWRs / 317 automated tests

## Commands Run
- `git fetch origin main feature/65-show-current-alert-duration-beside-the-status-pill`
- `cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DBUILD_TESTS=ON -Wno-dev`
- `cmake --build build --target test_unit test_integration`
- `ctest --test-dir build --output-on-failure`
- `@('','') | cmd /c run_tests.bat`
- `python dvt/run_dvt.py --no-build --build-dir build`

## Skipped Checks And Why
- `run_coverage.bat`: skipped because `gcovr` is not installed on this host
- Manual GUI review of abnormal transitions, pause/resume, and reset boundaries: not executed in this automated tester pass

## Medical-Safety And Security Notes
- display-only change; no thresholds, NEWS2 logic, alert generation, storage, network paths, or privileges changed
- residual manual verification remains the banner wording/layout check so severity stays primary and stale time-in-state cues clear on pause, device mode, logout, and session reset

## AI/ML Impact And Evidence
- none
