### PR TITLE
Feature: show latest-reading age in the dashboard header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The pipeline (`.github/workflows/pipeline.yml`) enforces this sequence — each 
 
 1. **Build All** — CMake + Ninja, all targets (Windows / MinGW-w64)
 2. **Static Analysis + SAST** — cppcheck + CodeQL (parallel, both gate on build)
-3. **Unit & Integration Tests** — GTest, 307 test cases
+3. **Unit & Integration Tests** — GTest, 312 test cases
 4. **Code Coverage** — gcovr, source-level line + branch coverage
 5. **DVT** — Design Verification Tests with IEC 62304 report
 6. **Publish Reports** — GitHub Pages dashboard (main branch only)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(ENABLE_COVERAGE "Enable GCC/Clang coverage instrumentation" OFF)
 # Production library — shared by app and all test targets
 # -------------------------------------------------------
 add_library(monitor_lib STATIC
+    src/dashboard_freshness.c
     src/vitals.c
     src/alerts.c
     src/patient.c

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Medical device software for real-time patient vital sign monitoring and alert generation.
 Built to **IEC 62304 Class B** and **FDA SW Validation Guidance** standards.
-**Version 2.7.0** — Six vital signs (including respiration rate), NEWS2 early warning score, configurable alarm limits (IEC 60601-1-8), trend sparkline graphs, a session alarm event review log, role-based settings access, rolling status message in simulation mode, 293 unit + 14 integration tests (307 total).
+**Version 2.7.0** — Six vital signs (including respiration rate), NEWS2 early warning score, configurable alarm limits (IEC 60601-1-8), trend sparkline graphs, a session alarm event review log, role-based settings access, rolling status message in simulation mode, a latest-reading freshness cue in the dashboard header, and 298 unit + 14 integration tests (312 total).
 
 ---
 
@@ -254,6 +254,16 @@ Trend direction detection and sparkline data extraction.
 
 ---
 
+### `dashboard_freshness.c` / `dashboard_freshness.h` — UNIT-GUI (freshness)
+
+Presentation-only freshness-state calculation for the dashboard header cue.
+
+| Function                         | Description                                                   |
+|----------------------------------|---------------------------------------------------------------|
+| `dashboard_freshness_compute()`  | Returns device/no-reading/live/paused freshness state + age   |
+
+---
+
 ## Alert Thresholds
 
 | Parameter    | NORMAL           | WARNING                          | CRITICAL              |
@@ -327,7 +337,7 @@ from a terminal.
 | Script                 | What it does                                                          |
 |------------------------|-----------------------------------------------------------------------|
 | `build.bat`            | Configure + build everything (first run or incremental). Launches GUI.|
-| `run_tests.bat`        | Rebuild test targets and run all 307 tests. Exits non-zero on failure.|
+| `run_tests.bat`        | Rebuild test targets and run all 312 tests. Exits non-zero on failure.|
 | `run_coverage.bat`     | Build with `--coverage`, run tests, generate HTML + XML reports.      |
 | `generate_docs.bat`    | Run Doxygen to produce HTML + XML design documentation.               |
 | `create_installer.bat` | Build release exe + compile Windows installer (`dist\` folder).       |
@@ -469,9 +479,10 @@ requirements revision.
 | `tests/unit/test_hal.cpp`                       | 12     | Supporting HAL / simulator checks only |
 | `tests/unit/test_config.cpp`                    | 10     | Supporting config persistence checks only |
 | `tests/unit/test_localization.cpp`              | 8      | SWR-GUI-012                       |
+| `tests/unit/test_dashboard_freshness.cpp`       | 5      | SWR-GUI-014                       |
 | `tests/integration/test_patient_monitoring.cpp` | 7      | SWR-PAT-*, SWR-VIT-*, SWR-ALT-*   |
 | `tests/integration/test_alert_escalation.cpp`   | 7      | SWR-VIT-*, SWR-ALT-*, SWR-PAT-007 |
-| **Total**                                       | **307** | **40 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
+| **Total**                                       | **312** | **41 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
 
 ### Test techniques applied
 
@@ -663,11 +674,11 @@ medvital-monitor/
 ├── requirements/
 |   |-- UNS.md                       # User Needs (17 items)
 |   |-- SYS.md                       # System Requirements (21 items)
-│   ├── SWR.md                       # Software Requirements (40 items)
-│   └── TRACEABILITY.md              # RTM — 17/17 UNS, 40/40 SWR, 307 tests
+│   ├── SWR.md                       # Software Requirements (41 items)
+│   └── TRACEABILITY.md              # RTM — 17/17 UNS, 41/41 SWR, 312 tests
 │
 ├── build.bat                        # Configure + build + launch GUI
-|-- run_tests.bat                    # Run all 307 tests
+|-- run_tests.bat                    # Run all 312 tests
 ├── run_coverage.bat                 # GCC coverage report (gcov + gcovr)
 ├── generate_docs.bat                # Doxygen HTML + XML documentation
 ├── create_installer.bat             # Build release + compile Windows installer

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,7 +215,7 @@ patient-vital-signs-monitor/
 │   ├── gui_main.c        # Presentation: Win32 dashboard
 │   └── main.c            # CLI entry point
 ├── tests/
-│   ├── unit/             # 293 unit tests
+│   ├── unit/             # 298 unit tests
 │   └── integration/      # 14 integration tests
 ├── dvt/                  # Design Verification Testing
 │   ├── DVT_Protocol.md   # DVT-001-REV-A

--- a/docs/DEVOPS_WORKFLOWS.md
+++ b/docs/DEVOPS_WORKFLOWS.md
@@ -27,7 +27,7 @@ dispatch.
  │  ┌───────────┐    ┌──────────────────┐    ┌───────────────────────┐     │
  │  │ 1. BUILD  │───▸│ 2a. CPPCHECK     │───▸│ 3. UNIT & INTEGRATION │     │
  │  │   ALL     │    │    (ubuntu)       │    │    TESTS              │     │
- │  │ (windows) │    ├──────────────────┤    │    307 GTest cases    │     │
+ │  │ (windows) │    ├──────────────────┤    │    312 GTest cases    │     │
  │  └───────────┘    │ 2b. CODEQL       │───▸│    (windows)          │     │
  │                   │    (windows)      │    └───────────┬───────────┘     │
  │                   └──────────────────┘                │                 │
@@ -129,7 +129,7 @@ activity for Class B software.
 |-------------|-----------------------------------------------|
 | Runner      | `windows-latest`                              |
 | Framework   | Google Test (release-1.10.0)                   |
-| Unit tests  | 293 tests across 30 suites                     |
+| Unit tests  | 298 tests across 32 suites                     |
 | Integration | 14 tests across 2 suites                       |
 | Output      | JUnit XML → artefact (90-day retention)        |
 | Summary     | Pass/fail table in Actions job summary         |
@@ -148,6 +148,7 @@ activity for Class B software.
 | `test_hal.cpp`           | 12    | Supporting HAL / simulator checks |
 | `test_config.cpp`        | 10    | Supporting config persistence checks |
 | `test_localization.cpp`  | 8     | SWR-GUI-012                      |
+| `test_dashboard_freshness.cpp` | 5 | SWR-GUI-014                      |
 | `test_patient_monitoring.cpp` | 7 | End-to-end vital to alert flow plus historical event retention |
 | `test_alert_escalation.cpp` | 7  | Alert to NEWS2 to alarm escalation plus parameter-set review transitions |
 

--- a/docs/history/risk/72-show-latest-reading-age-in-the-dashboard-header.md
+++ b/docs/history/risk/72-show-latest-reading-age-in-the-dashboard-header.md
@@ -1,0 +1,251 @@
+# Risk Note: Issue 72
+
+Date: 2026-05-06
+Issue: `#72` - Feature: show latest-reading age in the dashboard header
+Branch: `feature/72-show-latest-reading-age-in-the-dashboard-header`
+
+## proposed change
+
+Add a passive freshness cue to the live dashboard header or patient bar that
+shows the age or timestamp of the latest accepted reading. The intended scope is
+presentation-only metadata on top of the existing `patient_latest_reading()`
+and dashboard refresh path.
+
+The change must not alter alert thresholds, NEWS2 scoring, missing-reading
+handling, alarm escalation, hardware acquisition behavior, or treatment
+guidance. It must remain a read-only context aid for already accepted data.
+
+## product hypothesis and intended user benefit
+
+Operators can currently see live values and whether simulation is live or
+paused, but they cannot tell at a glance how old the displayed reading is.
+Adding a small deterministic freshness cue may reduce the chance that a paused
+or delayed screen is mistaken for current data.
+
+The user benefit is ergonomic and situational-awareness focused, not clinical
+decision automation. It improves confidence about display recency without
+changing what the system classifies as normal, warning, or critical.
+
+## source evidence quality
+
+Source evidence quality is moderate for product-discovery precedent and low for
+clinical or safety justification.
+
+- The issue cites public Mindray operator-manual material showing time-oriented
+  trend review or trend-table displays. Search-indexed manual excerpts confirm
+  that time context on patient monitors is a normal UX pattern.
+- Those sources are still untrusted product-discovery context only. They do not
+  justify copying layout, terminology, or claims, and they are not clinical
+  evidence for safety effectiveness.
+- Repo evidence is stronger for current-state fit: `README.md` and
+  `include/hw_vitals.h` describe an approximately 2-second acquisition cadence,
+  `src/gui_main.c` already exposes `* SIM LIVE` and `SIM PAUSED`, and the
+  current `VitalSigns` / `PatientRecord` structures do not contain timestamp
+  metadata.
+
+Conclusion: there is enough public and repo-local evidence to support a narrow,
+non-copying MVP for a freshness cue.
+
+## medical-safety impact
+
+Medical-safety impact is low to moderate.
+
+The proposed feature can reduce an existing workflow ambiguity by helping a
+human notice that displayed values are not recent. That is safety-positive.
+However, if the cue is wrong or misleading, it can create false reassurance and
+contribute to delayed recognition of stale data.
+
+The risk remains bounded because the feature does not change thresholds, alert
+generation, NEWS2, or patient-record contents if the scope is contained.
+
+## security and privacy impact
+
+No security-control or privacy-boundary change is expected if freshness is
+derived locally from the accepted-reading event and not persisted or exported.
+
+Main integrity risks:
+
+- deriving display time from an ambiguous wall clock instead of accepted-reading
+  state
+- implying time synchronization, device connectivity health, or data validity
+  that the system does not actually verify
+
+Privacy impact is none expected because no new patient fields, user data,
+credentials, or network flows are required for the MVP.
+
+## affected requirements or "none"
+
+Adjacent existing requirements:
+
+- `UNS-014` Graphical User Interface
+- `UNS-015` Live Monitoring Feed
+- `SYS-014` Graphical Vital Signs Dashboard
+- `SWR-GUI-003` Colour-Coded Vital Signs Display
+- `SWR-GUI-005` Hardware Abstraction Layer Interface
+- `SWR-GUI-006` Simulated Vital Signs Data Feed
+
+No new clinical-behavior requirement is needed if the implementation remains a
+passive display-only cue. If the design adds stale-data alarm semantics,
+connectivity claims, or workflow gating, requirements must be updated before
+implementation.
+
+## intended use, user population, operating environment, and foreseeable misuse
+
+Intended use: help trained users of the Windows dashboard judge whether the
+currently displayed reading is recent enough to treat as the latest accepted
+sample.
+
+User population: trained clinical operators and administrators using the pilot
+monitoring dashboard.
+
+Operating environment: a Windows workstation running the Win32 GUI in
+simulation mode today, with a future HAL-backed real-device mode possible.
+
+Foreseeable misuse:
+
+- treating the freshness cue as an alarm or safety interlock
+- assuming the cue proves sensor connectivity or device-clock synchronization
+- interpreting "fresh" as clinically stable rather than merely recently updated
+- assuming paused or cleared sessions still represent current patient state
+
+## severity, probability, initial risk, risk controls, verification method, residual risk, and residual-risk acceptability rationale
+
+- Severity: low to medium. A misleading freshness cue could contribute to a
+  delayed human response to stale data, but it cannot directly change clinical
+  classification if kept presentation-only.
+- Probability: low, provided the cue is derived from the accepted-reading event
+  and explicitly handles paused/no-data states.
+- Initial risk: low-medium.
+- Risk controls: derive freshness from the accepted-reading boundary rather than
+  repaint timing; use neutral wording such as `Last update` instead of
+  diagnostic language; distinguish no-reading, live, paused, and stale states;
+  avoid reusing alarm colors or claims; keep static-memory behavior; do not
+  change alerting or NEWS2 logic in the same work item.
+- Verification method: targeted unit tests if a helper computes age/state;
+  manual GUI verification for first-reading, steady live updates, paused feed,
+  clear-session reset, full-buffer reset, and simulation/device-mode behavior;
+  regression confirmation that alert outputs and NEWS2 are unchanged.
+- Residual risk: low.
+- Residual-risk acceptability rationale: with explicit non-clinical semantics
+  and correct paused/no-data handling, the feature reduces ambiguity in the
+  pilot dashboard and does not expand automated clinical decision-making.
+
+## hazards and failure modes
+
+- The cue refreshes from UI repaint cadence instead of the accepted-reading
+  event, making stale data appear current.
+- The cue continues to look "fresh" while the feed is paused or after the
+  patient session is cleared.
+- An absolute timestamp is shown without a defined provenance, locale, or clock
+  policy, misleading users about real acquisition time.
+- The implementation uses alert-like colors or wording that can be confused
+  with warning/critical clinical status.
+- The issue grows into stale-data alarm logic, workflow blocking, or device
+  connectivity assertions without approved requirements.
+- Designers copy competitor layout or interaction patterns too closely instead
+  of implementing a repo-native cue.
+
+## existing controls
+
+- The issue body explicitly constrains the change to presentation-only
+  metadata, separate from alarms, NEWS2, and interpretation.
+- `src/gui_main.c` already distinguishes `* SIM LIVE` from `SIM PAUSED`,
+  which gives the design an existing state signal to preserve.
+- `include/hw_vitals.h` and the README document an approximately 2-second
+  refresh cadence, so the product already has a stable concept of update
+  frequency.
+- `patient_latest_reading()` provides a single latest-reading access path.
+- `VitalSigns` and `PatientRecord` currently have no timestamp member, which
+  forces an explicit design decision instead of silently reusing nonexistent
+  acquisition-time metadata.
+- Production code already follows static-memory constraints, reducing the risk
+  of an ad hoc state-management expansion.
+
+## required design controls
+
+- Record freshness at the accepted-reading boundary, not in `WM_PAINT` or other
+  repaint-only code.
+- Prefer an age-based MVP such as `Updated 4 s ago` over an absolute timestamp
+  unless clock provenance and formatting rules are explicitly defined.
+- Keep wording passive and non-clinical. Good examples: `Last update`,
+  `Updated 4 s ago`, `Feed paused`. Bad examples: `Data valid`, `Patient OK`,
+  `Sensor connected`.
+- Distinguish at least four states: no reading yet, live recent reading,
+  paused/frozen feed, and stale/no new reading beyond the agreed threshold.
+- Keep freshness styling visually separate from the green/amber/red clinical
+  alert semantics already used elsewhere in the dashboard.
+- Do not add persistence, export, networking, or audit claims as part of this
+  MVP.
+- Do not change alert thresholds, aggregate status, NEWS2, or missing-reading
+  policy in the same issue.
+
+## MVP boundary that avoids copying proprietary UX
+
+Implement one small repo-native freshness cue in the existing header or patient
+bar, using the current typography and layout language of the Win32 dashboard.
+
+Acceptable MVP examples:
+
+- `Last update: 4 s ago`
+- `Last reading: 14:32:08`
+- `Feed paused - last update 18 s ago`
+
+Out of scope:
+
+- recreating competitor trend-table or trend-review layouts
+- cloning vendor terminology, iconography, alarm treatments, or navigation
+- introducing history browsers, cursor-driven time review, or printed trend
+  workflows
+
+## clinical-safety boundary and claims that must not be made
+
+This feature must not:
+
+- claim the patient is clinically stable, safe, or improving
+- claim the feed is synchronized to a trusted external clock
+- claim the sensor or hardware link is healthy
+- suppress, escalate, or reinterpret alarms
+- replace explicit missing-data, device-fault, or clinician-review workflows
+
+It is a freshness cue only.
+
+## validation expectations
+
+- Inspect the changed file list and diff to confirm presentation-only scope.
+- If new state is added, confirm it remains static-memory safe and bounded.
+- Manually verify: no-reading state, first accepted reading, steady live
+  refresh, paused feed, clear session, full-buffer rollover/reset, and
+  simulation/device-mode transitions.
+- Confirm the cue changes only when a reading is accepted or when an explicit
+  paused/no-data state change occurs.
+- Confirm alert tiles, alert list, aggregate status, and NEWS2 output are
+  unchanged by the feature.
+- If an absolute timestamp is chosen instead of age-only wording, verify the
+  chosen format, locale behavior, and clock provenance explicitly.
+
+## residual risk for this pilot
+
+Residual risk is low. The main remaining risk is user overtrust if wording,
+state handling, or visual treatment is sloppy. A bounded passive cue with
+clear paused/no-data semantics is acceptable for this pilot.
+
+## human owner decision needed, if any
+
+Yes. A human product/design owner should choose and document one approved
+semantic before design proceeds:
+
+1. age-only display (`Updated X sec ago`) - preferred for MVP
+2. absolute timestamp (`Last reading 14:32:08`)
+3. both age and timestamp
+
+If the team wants a visual stale threshold, the owner must also approve the
+threshold and confirm that it is not an alarm or treatment recommendation.
+
+## whether the candidate is safe to send to Architect
+
+Yes, with the controls above. This issue is safe to send to Architect as a
+passive freshness-metadata feature.
+
+It is not safe to expand this issue into alarming, device-connectivity claims,
+clock-synchronization claims, or other clinical workflow changes without new
+requirements and explicit human approval.

--- a/docs/history/specs/72-show-latest-reading-age-in-the-dashboard-header.md
+++ b/docs/history/specs/72-show-latest-reading-age-in-the-dashboard-header.md
@@ -1,0 +1,326 @@
+# Design Spec: Show latest-reading age in the dashboard header
+
+Issue: #72
+Branch: `feature/72-show-latest-reading-age-in-the-dashboard-header`
+Spec path: `docs/history/specs/72-show-latest-reading-age-in-the-dashboard-header.md`
+
+## Problem
+
+Issue #72 identifies a live-dashboard ambiguity: operators can see the latest
+vital values and whether simulation is live or paused, but they cannot tell at
+a glance how old the currently displayed reading is. Today the UI exposes
+`* SIM LIVE` / `SIM PAUSED`, the patient summary bar, and the latest tiles, but
+it does not show when the current reading was last accepted into the session.
+
+That gap is small but meaningful. A paused or delayed screen can be mistaken
+for current data even though the monitor is only repainting stale values. The
+feature must reduce that ambiguity without changing thresholds, alert logic,
+NEWS2, missing-reading handling, HAL behavior, or any clinical claim.
+
+## Goal
+
+Add one passive, deterministic freshness cue to the dashboard header that tells
+the operator how long ago the latest reading was accepted.
+
+The intended outcome is:
+
+- the header shows a small read-only cue such as `Last update: 4 s ago`
+- the cue is derived from accepted-reading events, not from repaint timing
+- paused sessions remain visibly paused and continue to show growing age
+- no domain structs, alert semantics, NEWS2 logic, or persistence rules change
+
+For this MVP, staleness is communicated by the age value itself. The design
+does not add a separate stale-data threshold, alarm state, or connectivity
+claim.
+
+## Non-goals
+
+- No change to vital-sign classification, aggregate alerting, NEWS2 scoring,
+  alarm limits, authentication, localization selection, or patient persistence.
+- No absolute wall-clock timestamp display, locale-specific time formatting, or
+  time-of-day provenance claim.
+- No new stale-data alarm, workflow lockout, device-fault detection, or sensor
+  connectivity indicator.
+- No change to `PatientRecord`, `VitalSigns`, `patient_latest_reading()`, or
+  HAL acquisition APIs for this MVP.
+- No persistence, export, audit-log, networking, or requirements-free scope
+  expansion beyond the bounded freshness cue.
+
+## Intended use impact, user population, operating environment, and foreseeable misuse
+
+Intended use impact is limited to display ergonomics. The cue helps trained
+operators judge whether the visible reading is recent enough to treat as the
+latest accepted sample, but it does not interpret patient condition.
+
+User population remains the same: trained clinical and admin users of the Win32
+dashboard. The operating environment remains the current Windows desktop
+application, primarily in simulation mode today, with the same future HAL-backed
+device mode already documented elsewhere.
+
+Foreseeable misuse that the implementation must avoid:
+
+- treating the cue as an alarm or proof of data validity
+- assuming the cue proves hardware connectivity or trusted clock sync
+- confusing a paused feed with a clinically stable patient
+- interpreting a large age value as a formal stale-data threshold when no such
+  threshold is approved in this issue
+
+## Current behavior
+
+Current dashboard behavior in `src/gui_main.c` is close to what this feature
+needs, but it lacks freshness state:
+
+- `paint_header()` renders the title, logged-in user badge, and the simulation
+  state text (`* SIM LIVE` or `SIM PAUSED`)
+- `paint_patient_bar()` renders patient demographics, BMI, and reading count
+- `update_dashboard()` rebuilds reading history and active-alert lists from the
+  latest accepted `PatientRecord` sample
+- accepted readings enter the session through `patient_add_reading()` call
+  sites in `do_add_reading()`, `do_scenario()`, `apply_sim_mode()`, initial
+  dashboard startup, and the `WM_TIMER` simulation loop
+- paused mode currently prevents new readings, but it also prevents the visible
+  age from changing because `WM_TIMER` exits early when `g_app.sim_paused == 1`
+- `PatientRecord` and `VitalSigns` contain no timestamp field today
+
+## Proposed change
+
+Implement the feature as a presentation-layer freshness model with no domain
+data-model change.
+
+### 1. Record freshness in GUI state only
+
+Add bounded runtime state to `AppState` in `src/gui_main.c`:
+
+- `ULONGLONG last_reading_tick_ms`
+- `int has_last_reading_tick`
+
+Capture the timestamp with `GetTickCount64()` only when a reading is actually
+accepted into the current session. Do not add timestamp members to
+`VitalSigns` or `PatientRecord`, and do not persist freshness across launches.
+
+### 2. Stamp the accepted-reading boundary, not repaint
+
+Create one shared GUI-side helper path, for example
+`accept_reading_and_stamp(...)`, that calls `patient_add_reading()` and updates
+`last_reading_tick_ms` only on success.
+
+Use that path for every accepted-reading source:
+
+- initial simulation reading during dashboard startup
+- `apply_sim_mode()` when simulation is enabled
+- `WM_TIMER` when a live simulated reading is acquired
+- manual `Add Reading`
+- demo scenario injection after the final sample becomes current
+
+Clear the freshness state when the current session is reset or discarded:
+
+- `do_admit()` before any new reading is added
+- `do_clear()`
+- device-mode transition that zeroes the patient session
+- logout
+
+### 3. Keep the age calculation testable outside Win32 paint code
+
+Add a small pure helper dedicated to freshness-state calculation, for example:
+
+- `include/dashboard_freshness.h`
+- `src/dashboard_freshness.c`
+- `tests/unit/test_dashboard_freshness.cpp`
+
+That helper should stay outside `monitor_lib` because it is presentation logic,
+not domain logic. It should accept current monotonic tick, last accepted tick,
+and dashboard mode flags, then return a small model such as:
+
+- display state enum: `DEVICE_MODE`, `NO_READING`, `LIVE_AGE`, `PAUSED_AGE`
+- whole-second age for the latest reading when applicable
+
+Formatting may remain in `gui_main.c`, but the state and age computation should
+be deterministic and unit-testable.
+
+### 4. Render one neutral header cue
+
+Render the freshness cue as a secondary header line under the app title on the
+left side of the top banner, using neutral text styling that does not reuse the
+green/amber/red clinical alert palette.
+
+Approved MVP semantics:
+
+- simulation disabled: no freshness cue; preserve existing device-mode text
+- simulation enabled, no reading yet: `Last update: awaiting first reading`
+- simulation enabled, actively updating: `Last update: <N> s ago`
+- simulation enabled, paused: `Feed paused - last update: <N> s ago`
+
+For this issue, use age-only wording. Do not display wall-clock time, and do
+not add a separate stale threshold or alarm color. If the age grows large, that
+age itself is the operator-visible stale signal.
+
+### 5. Allow paused mode to keep aging without acquiring new data
+
+Retain the existing 2-second timer while simulation mode is enabled, but split
+timer behavior into:
+
+- acquisition path when `sim_paused == 0`
+- repaint/age refresh path when `sim_paused == 1`
+
+That means paused mode should still invalidate or refresh the dashboard so the
+freshness cue can change from `4 s ago` to `6 s ago` to `8 s ago`, while no new
+sample is acquired and no patient data changes underneath it.
+
+Do not introduce a second scheduler, background worker, or persisted clock
+mechanism for this MVP.
+
+### 6. Localize the new header strings
+
+Route the cue text through the existing localization layer rather than adding
+hard-coded English-only header text. The simplest acceptable shape is a small
+set of new string IDs and format strings for:
+
+- `Last update: awaiting first reading`
+- `Last update: %lu s ago`
+- `Feed paused - last update: %lu s ago`
+
+Keep the output static-memory safe by formatting into caller-owned stack
+buffers, matching existing UI patterns.
+
+## Files expected to change
+
+Expected production/UI files:
+
+- `src/gui_main.c`
+- `include/localization.h`
+- `src/localization.c`
+- `CMakeLists.txt`
+- `tests/CMakeLists.txt`
+
+Expected new helper and test files:
+
+- `include/dashboard_freshness.h`
+- `src/dashboard_freshness.c`
+- `tests/unit/test_dashboard_freshness.cpp`
+
+Expected documentation/traceability files:
+
+- `requirements/SYS.md`
+- `requirements/SWR.md`
+- `requirements/TRACEABILITY.md`
+- `docs/history/specs/72-show-latest-reading-age-in-the-dashboard-header.md`
+
+Existing related design-control input already present on the branch:
+
+- `docs/history/risk/72-show-latest-reading-age-in-the-dashboard-header.md`
+
+Files that should not change for this issue:
+
+- `include/patient.h`
+- `src/patient.c`
+- `include/vitals.h`
+- `src/vitals.c`
+- `src/alerts.c`
+- `src/news2.c`
+- alarm-limit logic, authentication logic, or HAL interface contracts
+
+## Requirements and traceability impact
+
+This is a new patient-facing dashboard behavior, so traceability should be made
+explicit rather than implied.
+
+Recommended requirement update strategy:
+
+- amend `SYS-014` to mention a passive freshness cue for the latest accepted
+  reading in the graphical dashboard
+- add a new software requirement, preferably `SWR-GUI-013`, that defines:
+  accepted-reading-boundary semantics, age-only display wording, no-reading and
+  paused states, monotonic timing basis, and no effect on alerting/NEWS2
+- add RTM coverage linking the new SWR to `UNS-014`, `UNS-015`, and `SYS-014`
+- trace implementation to `src/gui_main.c` plus the new freshness helper, and
+  trace verification to new unit tests plus manual GUI review
+
+This feature should not introduce a new SYS or SWR tied to alarms, device
+health, or clinical interpretation.
+
+## Medical-safety, security, and privacy impact
+
+Medical-safety impact is low and bounded. The cue is safety-positive only as a
+situational-awareness aid; it must not change patient classification or imply
+clinical validity beyond "this is how long ago the latest reading was accepted."
+
+Security impact is low. The design adds no privilege boundary, file format,
+network path, or credential change. Using a monotonic in-memory tick avoids
+false precision and avoids creating a persisted clock-derived artifact.
+
+Privacy impact is none expected. No new patient-identifying field, export path,
+or retained timestamp history is introduced.
+
+## AI/ML impact assessment
+
+This issue does not add, change, remove, or depend on an AI-enabled device
+software function.
+
+- Model purpose: none
+- Input data: none beyond existing non-AI vital-reading acceptance events
+- Output: none
+- Human-in-the-loop limits: unchanged
+- Transparency needs: unchanged
+- Dataset and bias considerations: not applicable
+- Monitoring expectations: unchanged
+- PCCP impact: none
+
+## Validation plan
+
+Validation should prove that the feature remains presentation-only and derives
+age from accepted readings correctly across live and paused states.
+
+Build and automated checks:
+
+```powershell
+cmake -S . -B build -G Ninja -DBUILD_TESTS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure -R UnitTests
+```
+
+Targeted unit-test expectations for the new helper:
+
+- device mode returns no freshness cue state
+- no-reading session returns waiting state
+- live mode computes whole-second age from monotonic ticks
+- paused mode reuses the same age basis but changes semantic state
+- missing timestamp state fails safe to no-reading/waiting semantics
+
+Manual GUI verification:
+
+- startup with simulation enabled: first accepted reading shows `0 s ago` or
+  the first timer-aligned age immediately after session start
+- live simulation: age resets on each accepted reading and advances between
+  acquisitions without affecting tiles or alerts
+- paused simulation: no new reading is added, but the displayed age continues
+  to increase on the existing timer cadence
+- manual `Add Reading`: age resets when the manual reading is accepted
+- `Admit / Refresh`: session freshness resets to waiting-for-first-reading
+- `Clear Session`: freshness cue disappears or returns to waiting state
+- demo scenarios: final injected reading becomes the current reading and age
+  starts from that acceptance moment
+- full-buffer rollover/reset in `WM_TIMER`: the new post-reset reading becomes
+  the current freshness origin
+- simulation disabled/device mode: existing device-mode messaging remains and
+  no misleading freshness cue is shown
+
+Regression checks:
+
+- `patient_latest_reading()` behavior is unchanged
+- reading history, alert list, aggregate status banner, and NEWS2 tile remain
+  behaviorally unchanged
+- no new heap allocation or persistence path is introduced
+
+## Rollback or failure handling
+
+If implementation cannot keep the feature presentation-only, stop and split the
+work rather than silently broadening it into device-health or stale-data alarm
+logic.
+
+If paused-mode age refresh becomes unstable, keep the existing timer and reduce
+the feature to a live/paused waiting cue rather than introducing a second clock
+or background scheduler in the same issue.
+
+If reviewers reject the requirement delta, remove the freshness cue entirely and
+restore the previous header behavior; do not partially ship an untraced
+patient-facing display feature.

--- a/docs/history/specs/72-show-latest-reading-age-in-the-dashboard-header.md
+++ b/docs/history/specs/72-show-latest-reading-age-in-the-dashboard-header.md
@@ -228,7 +228,7 @@ Recommended requirement update strategy:
 
 - amend `SYS-014` to mention a passive freshness cue for the latest accepted
   reading in the graphical dashboard
-- add a new software requirement, preferably `SWR-GUI-013`, that defines:
+- add a new software requirement, using the next available GUI identifier (`SWR-GUI-014` on the rebased branch), that defines:
   accepted-reading-boundary semantics, age-only display wording, no-reading and
   paused states, monotonic timing basis, and no effect on alerting/NEWS2
 - add RTM coverage linking the new SWR to `UNS-014`, `UNS-015`, and `SYS-014`

--- a/dvt/DVT_Protocol.md
+++ b/dvt/DVT_Protocol.md
@@ -73,6 +73,7 @@ Automated GUI checks supplement but do not replace the GTest evidence used by
 | `SWR-GUI-011` | Manual visual review | Rolling status message content/motion is not asserted by current automation |
 | `SWR-GUI-012` | Unit tests + supplemental automation | `LocalizationTest.*` covers API and persistence; `DVT-GUI-16` confirms selector presence with four options |
 | `SWR-GUI-013` | Manual GUI review | Dedicated session alarm event list must stay distinct from current active alerts and disclose any bounded session reset |
+| `SWR-GUI-014` | Unit tests + manual GUI review | `DashboardFreshness.REQ_GUI_014_*` covers freshness-state computation; `GUI-MAN-07` confirms live, paused, waiting, reset, and device-mode header behavior |
 
 ### 4.3 Residual Manual GUI Checklist
 
@@ -87,6 +88,7 @@ layout behavior, or animated presentation rather than stable control state.
 | GUI-MAN-04 | Layout robustness | Resize dashboard window | Controls repaint and scale without clipping/overlap | |
 | GUI-MAN-05 | Layout robustness | Maximize dashboard window | Full layout remains legible and anchored correctly | |
 | GUI-MAN-06 | `SWR-GUI-013` | Drive a warning, critical, then recovery sequence and continue until the bounded session resets | Session Alarm Events retains the historical rows while Active Alerts returns to latest-only state, then shows an explicit session-reset disclosure when earlier rows are cleared | |
+| GUI-MAN-07 | `SWR-GUI-014` | Enable simulation, observe the header before the first accepted reading, then let the feed run, pause it, resume it, and clear or admit a new session | The header shows awaiting-first-reading before acceptance, `Last update: <N> s ago` while live, `Feed paused - last update: <N> s ago` while paused with age continuing to increase, and the cue clears or hides on reset/device mode | |
 
 ---
 
@@ -106,7 +108,8 @@ layout behavior, or animated presentation rather than stable control state.
 | `tests/unit/test_hal.cpp` (`HALTest`, `HALTestNoInit`, `SimSequenceTest`) | 12 | Supporting checks for HAL safety and simulator sequence behavior; not an approved automated DVT claim for `SWR-GUI-005` / `SWR-GUI-006` |
 | `tests/unit/test_config.cpp` (`ConfigTest`) | 10 | Supporting persistence checks for `monitor.cfg`; not a full approved automated DVT claim for `SWR-GUI-010` |
 | `tests/unit/test_localization.cpp` (`LocalizationTest`) | 8 | `SWR-GUI-012` |
-| **Total** | **293** | |
+| `tests/unit/test_dashboard_freshness.cpp` (`DashboardFreshness`) | 5 | `SWR-GUI-014` |
+| **Total** | **298** | |
 
 ### 5.2 Integration Tests (`test_integration.exe`)
 
@@ -122,9 +125,9 @@ layout behavior, or animated presentation rather than stable control state.
 
 | Criterion | Threshold |
 |---|---|
-| Unit test pass rate | 100% (`293 / 293`) |
+| Unit test pass rate | 100% (`298 / 298`) |
 | Integration test pass rate | 100% (`14 / 14`) |
-| Automated GTest total | 100% (`307 / 307`) |
+| Automated GTest total | 100% (`312 / 312`) |
 | Automated GUI checks for approved IDs | All executed approved-ID checks pass |
 | Manual GUI checklist | All applicable manual items marked Pass |
 
@@ -165,3 +168,4 @@ may execute during validation, but they do not convert `SWR-GUI-005`,
 | C | 2026-05-03 | Codex implementer | Approved SWR-GUI-012 localization evidence and updated automated totals |
 | D | 2026-05-05 | Codex implementer | Added session alarm event review evidence, GUI-MAN-06, and updated automated totals to 305 tests |
 | E | 2026-05-06 | Codex implementer | Added session-reset disclosure evidence expectations and updated automated totals to 307 tests |
+| F | 2026-05-06 | Codex implementer | Added SWR-GUI-014 freshness-cue evidence, GUI-MAN-07, and updated automated totals to 312 tests |

--- a/dvt/run_dvt.py
+++ b/dvt/run_dvt.py
@@ -112,6 +112,7 @@ REQUIREMENT_MAP = {
     "SWR-GUI-011": (None, "MANUAL", "Rolling simulation banner verified by manual visual check"),
     "SWR-GUI-012": ("test_unit", "LocalizationTest", "Localization API, selector list, and monitor.cfg persistence"),
     "SWR-GUI-013": (None, "MANUAL", "GUI review: dedicated session alarm events list remains distinct from active alerts"),
+    "SWR-GUI-014": ("test_unit", "DashboardFreshness", "Dashboard freshness helper computes awaiting/live/paused states from accepted-reading ticks"),
     # GUI requirements verified via manual checklist only (GUI rendering and workflow review)
     "SWR-GUI-001": (None, "MANUAL", "Login screen: auth, error message, role detection"),
     "SWR-GUI-002": (None, "MANUAL", "Dashboard: colour-coded vital tiles update every 2 s"),
@@ -464,10 +465,11 @@ def generate_report(
     ln(sep_major)
     ln()
     ln("  NOTE: Non-automated GUI/architecture items (including SWR-GUI-001/002/003/004/")
-    ln("  005/006/007/008/009/010/011) are verified via the checklist and review")
+    ln("  005/006/007/008/009/010/011/013) are verified via the checklist and review")
     ln("  guidance in dvt/DVT_Protocol.md and are not")
     ln("  included in the automated pass/fail decision.")
     ln("  NOTE: SWR-GUI-012 automated coverage comes from LocalizationTest.*.")
+    ln("  NOTE: SWR-GUI-014 automated coverage comes from DashboardFreshness.REQ_GUI_014_*.")
     ln("  DVT-GUI-16 remains supplemental GUI evidence for selector presence.")
     ln()
     ln(sep_major)

--- a/include/dashboard_freshness.h
+++ b/include/dashboard_freshness.h
@@ -1,0 +1,32 @@
+#ifndef DASHBOARD_FRESHNESS_H
+#define DASHBOARD_FRESHNESS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    DASHBOARD_FRESHNESS_DEVICE_MODE = 0,
+    DASHBOARD_FRESHNESS_NO_READING,
+    DASHBOARD_FRESHNESS_LIVE_AGE,
+    DASHBOARD_FRESHNESS_PAUSED_AGE
+} DashboardFreshnessState;
+
+typedef struct {
+    DashboardFreshnessState state;
+    unsigned long age_seconds;
+} DashboardFreshness;
+
+DashboardFreshness dashboard_freshness_compute(int simulation_enabled,
+                                               int simulation_paused,
+                                               int has_last_reading_tick,
+                                               uint64_t current_tick_ms,
+                                               uint64_t last_reading_tick_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DASHBOARD_FRESHNESS_H */

--- a/include/localization.h
+++ b/include/localization.h
@@ -98,6 +98,9 @@ typedef enum {
     STR_REMOVE_USER,
     STR_ROLE,
     STR_ADMIN,
+    STR_LAST_UPDATE_WAITING,
+    STR_LAST_UPDATE_AGE_SECONDS,
+    STR_LAST_UPDATE_PAUSED_AGE_SECONDS,
     STR_CLINICAL,
 
     /* Status messages */

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -118,7 +118,7 @@ Before submitting for regulatory review, verify:
 - [ ] All requirement annotations in code comments refer to valid SWR IDs in `SWR.md`
 - [ ] All Google Test names follow the `REQ_XXX_NNN_Description` pattern
 - [ ] `docs/doxygen_warnings.log` is empty (no undocumented or malformed comments)
-- [ ] All 307 tests pass (`run_tests.bat`)
+- [ ] All 312 tests pass (`run_tests.bat`)
 - [ ] `AuthValidation.*` and `AuthDisplayName.*` (15 tests) all pass
 - [ ] Line coverage ≥ 99% for `vitals.c`, `alerts.c`, `patient.c` (`run_coverage.bat`)
 - [ ] No dynamic memory allocation in production code
@@ -134,3 +134,4 @@ Before submitting for regulatory review, verify:
 | B   | 2026-04-07 | vinu-engineer   | Updated for v1.3 GUI additions |
 | C   | 2026-05-05 | codex           | Updated RR example trace for SYS-018 / SWR-VIT-008 repair |
 | D   | 2026-05-06 | Codex implementer | Updated checklist totals for session-reset disclosure coverage |
+| E   | 2026-05-06 | Codex implementer | Updated checklist totals for the dashboard freshness cue coverage |

--- a/requirements/SWR.md
+++ b/requirements/SWR.md
@@ -717,6 +717,33 @@ session event label string
 
 ---
 
+### SWR-GUI-014 â€” Latest Reading Freshness Cue
+
+**Requirement:** When simulation mode is enabled, the dashboard header shall
+render one passive freshness cue derived only from the most recent
+successfully accepted reading. The GUI shall record a monotonic tick when a
+reading is accepted during dashboard startup, `apply_sim_mode()`,
+`WM_TIMER`-driven live acquisition, manual `Add Reading`, and demo scenario
+injection. The cue shall use localized strings and the following states:
+`Last update: awaiting first reading` when no reading has been accepted in the
+current session, `Last update: <N> s ago` while the simulation feed is live,
+`Feed paused - last update: <N> s ago` while the feed is paused, and no
+freshness cue in device mode. Resetting or discarding the current session
+shall clear the stored freshness state. Paused simulation shall continue to
+repaint on the existing timer cadence so the displayed age can continue to
+increase without acquiring a new reading. The cue shall not alter
+`PatientRecord`, alert generation, NEWS2 scoring, or alarm semantics.
+
+**Traces to:** SYS-014
+**Implemented in:** `src/gui_main.c` â€” `paint_header()`, `do_admit()`,
+`do_add_reading()`, `do_clear()`, `do_scenario()`, `apply_sim_mode()`,
+`dash_proc()`; `src/dashboard_freshness.c` â€” `dashboard_freshness_compute()`;
+`src/localization.c` â€” freshness header strings
+**Verified by:** `tests/unit/test_dashboard_freshness.cpp` â€” `DashboardFreshness.REQ_GUI_014_*`
+(5 tests); Manual GUI review (`GUI-MAN-07`)
+
+---
+
 ## Revision History
 
 | Rev | Date       | Author          | Description          |
@@ -734,3 +761,4 @@ session event label string
 | K   | 2026-05-05 | Codex implementer | Restored defensible SYS-level traceability for SWR-VIT-008 and SWR-NEW-001; no clinical behavior changes |
 | L   | 2026-05-05 | Codex implementer | Added SWR-PAT-007/008 and SWR-GUI-013 for session alarm event review |
 | M   | 2026-05-06 | Codex implementer | Added explicit session-reset disclosure expectations for session review surfaces |
+| N   | 2026-05-06 | Codex implementer | Added SWR-GUI-014 for the dashboard latest-reading freshness cue |

--- a/requirements/SYS.md
+++ b/requirements/SYS.md
@@ -163,7 +163,9 @@ active patient in a graphical dashboard using colour-coded status tiles:
 green for NORMAL, amber for WARNING, and red for CRITICAL. The aggregate
 alert status shall be displayed in a banner using the same colour convention.
 The dashboard shall refresh automatically after each new reading is added.
-**Traces to:** UNS-014, UNS-005, UNS-006, UNS-010
+When simulation mode is enabled, the header shall also show a passive
+freshness cue for the latest accepted reading using non-clinical wording.
+**Traces to:** UNS-014, UNS-005, UNS-006, UNS-010, UNS-015
 
 ---
 
@@ -266,3 +268,4 @@ events have been recorded.
 | D   | 2026-04-07 | vinu-engineer   | Added SYS-016 (multi-user accounts), SYS-017 (RBAC) |
 | E   | 2026-05-05 | Codex implementer | Added SYS-018 (RR) and SYS-019 (NEWS2) to restore defensible traceability for existing clinical requirements |
 | F   | 2026-05-05 | Codex implementer | Added SYS-020 and SYS-021 for session alarm event review |
+| G   | 2026-05-06 | Codex implementer | Expanded SYS-014 to require a passive latest-reading freshness cue in the dashboard header |

--- a/requirements/TRACEABILITY.md
+++ b/requirements/TRACEABILITY.md
@@ -48,6 +48,7 @@ implementation and test coverage, and every UNS must reach at least one SWR.
 | UNS-015 | SYS-015 | SWR-GUI-010 | `gui_main.c`, `app_config.c` : sim toggle + persistence | Manual GUI review + `ConfigTest.*` support (10 persistence checks) | — |
 | UNS-015 | SYS-005 | SWR-GUI-011 | `gui_main.c` : rolling message in sim mode (`paint_status_banner()`, scroll offset) | Manual visual review | — |
 | UNS-014 | SYS-014 | SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : language tab, selector strings, `monitor.cfg` persistence/load | `LocalizationTest.*` (8 tests) + supplemental `DVT-GUI-16` | — |
+| UNS-014, UNS-015 | SYS-014 | SWR-GUI-014 | `gui_main.c`, `dashboard_freshness.c`, `localization.c` : accepted-reading freshness cue, paused-age repaint, localized header strings | `DashboardFreshness.REQ_GUI_014_*` (5 tests) + Manual GUI review (`GUI-MAN-07`) | — |
 | UNS-005, UNS-006 | SYS-005 | SWR-ALT-001 | `alerts.c` : `generate_alerts()` | `REQ_ALT_002_*` (4 tests) | `REQ_INT_MON_004`, `REQ_INT_ESC_002`, `REQ_INT_ESC_003` |
 | UNS-005 | SYS-005 | SWR-ALT-002 | `alerts.c` : `generate_alerts()` | `REQ_ALT_001_*` (1 test) | `REQ_INT_ESC_004` |
 | UNS-011 | SYS-012 | SWR-ALT-003 | `alerts.c` : `generate_alerts()` | `REQ_ALT_004_*` (2 tests) | — |
@@ -113,6 +114,7 @@ implementation and test coverage, and every UNS must reach at least one SWR.
 | `UsersTest` | `REQ_SEC_004_*` | SWR-SEC-004 | SYS-017 | UNS-016 |
 | `UsersTest` | `REQ_GUI_007_*` | SWR-GUI-007 | SYS-016 | UNS-016 |
 | `LocalizationTest` | `LocalizationTest.*` | SWR-GUI-012 | SYS-014 | UNS-014 |
+| `DashboardFreshness` | `REQ_GUI_014_*` | SWR-GUI-014 | SYS-014 | UNS-014, UNS-015 |
 | `RespRate` | `REQ_VIT_008_*` | SWR-VIT-008 | SYS-018 | UNS-005, UNS-006, UNS-014, UNS-015 |
 | `News2HR`, `News2RR`, etc. | `News2*.*` | SWR-NEW-001 | SYS-019 | UNS-005, UNS-006, UNS-010, UNS-014 |
 | `AlarmLimitsTest` | `AlarmLimitsTest.*` | SWR-ALM-001 | SYS-002, SYS-003 | UNS-005, UNS-006 |
@@ -161,8 +163,8 @@ Supporting implementation checks:
 | UNS-011 | Data integrity | SYS-010, SYS-012 | SWR-PAT-002, SWR-PAT-005, SWR-ALT-003, SWR-PAT-001 | ✓ |
 | UNS-012 | Platform compatibility | SYS-012 | SWR-PAT-001, SWR-ALT-003 | ✓ |
 | UNS-013 | User authentication | SYS-013 | SWR-GUI-001, SWR-GUI-002 | ✓ |
-| UNS-014 | Graphical dashboard | SYS-014, SYS-018, SYS-019, SYS-021 | SWR-GUI-003, SWR-GUI-004, SWR-GUI-012, SWR-GUI-013, SWR-VIT-008, SWR-NEW-001 | ✓ |
-| UNS-015 | Live monitoring feed | SYS-015, SYS-018 | SWR-GUI-005, SWR-GUI-006, SWR-GUI-010, SWR-GUI-011, SWR-VIT-008 | ✓ |
+| UNS-014 | Graphical dashboard | SYS-014, SYS-018, SYS-019, SYS-021 | SWR-GUI-003, SWR-GUI-004, SWR-GUI-012, SWR-GUI-013, SWR-GUI-014, SWR-VIT-008, SWR-NEW-001 | ✓ |
+| UNS-015 | Live monitoring feed | SYS-014, SYS-015, SYS-018 | SWR-GUI-005, SWR-GUI-006, SWR-GUI-010, SWR-GUI-011, SWR-GUI-014, SWR-VIT-008 | ✓ |
 | UNS-016 | Role-based access / multi-user | SYS-016, SYS-017 | SWR-SEC-001, SWR-SEC-002, SWR-SEC-003, SWR-GUI-007, SWR-GUI-008, SWR-GUI-009 | ✓ |
 | UNS-017 | Session alarm event review | SYS-020, SYS-021 | SWR-PAT-006, SWR-PAT-007, SWR-PAT-008, SWR-GUI-013 | ✓ |
 
@@ -212,12 +214,13 @@ Supporting implementation checks:
 | SWR-GUI-011 | `gui_main.c` : `paint_status_banner()`, scroll offset | Manual visual review | — | ✓ |
 | SWR-GUI-012 | `gui_main.c`, `localization.c`, `app_config.c` : selector strings, persistence/load | `LocalizationTest.*` (8) + supplemental `DVT-GUI-16` | — | ✓ |
 | SWR-GUI-013 | `create_dash_controls()`, `reposition_dash_controls()`, `update_dashboard()` | Manual GUI review (`GUI-MAN-06`) | — | ✓ |
+| SWR-GUI-014 | `gui_main.c`, `dashboard_freshness.c`, `localization.c` : latest-reading freshness cue | `DashboardFreshness.REQ_GUI_014_*` (5) + Manual GUI review (`GUI-MAN-07`) | — | ✓ |
 | SWR-VIT-008 | `vitals.c` : `check_respiration_rate()` | 15 | — | ✓ |
 | SWR-NEW-001 | `news2.c` : `news2_calculate()` | 53 | — | ✓ |
 | SWR-ALM-001 | `alarm_limits.c` : `alarm_limits_defaults()`, `alarm_check_*()` | 31 | — | ✓ |
 | SWR-TRD-001 | `trend.c` : `trend_direction()`, `trend_extract_*()` | 18 | — | ✓ |
 
-**Result: 40 / 40 SWRs implemented and tested ✓**
+**Result: 41 / 41 SWRs implemented and tested ✓**
 
 ---
 
@@ -269,9 +272,10 @@ This is recorded as an accepted coverage exclusion with a documented rationale.
 | `tests/unit/test_hal.cpp` | 12 | Supporting HAL / simulator checks only; no direct SWR verification claim |
 | `tests/unit/test_config.cpp` | 10 | Supporting config persistence checks only; no direct SWR verification claim |
 | `tests/unit/test_localization.cpp` | 8 | SWR-GUI-012 |
+| `tests/unit/test_dashboard_freshness.cpp` | 5 | SWR-GUI-014 |
 | `tests/integration/test_patient_monitoring.cpp` | 7 | SWR-PAT-*, SWR-VIT-*, SWR-ALT-* |
 | `tests/integration/test_alert_escalation.cpp` | 7 | SWR-VIT-*, SWR-ALT-*, SWR-PAT-004, SWR-PAT-007 |
-| **Total** | **307** | **40 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
+| **Total** | **312** | **41 SWRs covered across automated, architecture-review, and GUI-demo/manual evidence** |
 
 ---
 
@@ -291,3 +295,4 @@ This is recorded as an accepted coverage exclusion with a documented rationale.
 | J   | 2026-05-05 | Codex implementer | Restored defensible SYS-level traceability for RR and NEWS2 requirements; 37/37 SWR, 295 tests |
 | K   | 2026-05-05 | Codex implementer | Added session alarm event review traceability: UNS-017, SYS-020/021, SWR-PAT-007/008, SWR-GUI-013; 40/40 SWR, 305 tests |
 | L   | 2026-05-06 | Codex implementer | Added session-reset disclosure traceability and updated automated totals to 307 tests |
+| M   | 2026-05-06 | Codex implementer | Added SWR-GUI-014 traceability for the dashboard freshness cue and updated automated totals to 312 tests |

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -3,7 +3,7 @@ setlocal enabledelayedexpansion
 
 echo =====================================================
 echo   Patient Vital Signs Monitor -- Test Runner
-echo   307 tests: Unit (293) + Integration (14)
+echo   312 tests: Unit (298) + Integration (14)
 echo   Standard : IEC 62304 Class B
 echo =====================================================
 echo.
@@ -87,7 +87,7 @@ echo.
 :: Summary and exit code
 :: -------------------------------------------------------
 if !UNIT_RESULT! EQU 0 if !INT_RESULT! EQU 0 (
-    echo [PASS] All 307 tests passed.
+    echo [PASS] All 312 tests passed.
     echo.
     pause
     exit /b 0

--- a/src/dashboard_freshness.c
+++ b/src/dashboard_freshness.c
@@ -1,0 +1,33 @@
+#include "dashboard_freshness.h"
+
+DashboardFreshness dashboard_freshness_compute(int simulation_enabled,
+                                               int simulation_paused,
+                                               int has_last_reading_tick,
+                                               uint64_t current_tick_ms,
+                                               uint64_t last_reading_tick_ms)
+{
+    DashboardFreshness freshness;
+
+    freshness.age_seconds = 0UL;
+
+    if (!simulation_enabled) {
+        freshness.state = DASHBOARD_FRESHNESS_DEVICE_MODE;
+        return freshness;
+    }
+
+    if (!has_last_reading_tick) {
+        freshness.state = DASHBOARD_FRESHNESS_NO_READING;
+        return freshness;
+    }
+
+    freshness.state = simulation_paused
+        ? DASHBOARD_FRESHNESS_PAUSED_AGE
+        : DASHBOARD_FRESHNESS_LIVE_AGE;
+
+    if (current_tick_ms >= last_reading_tick_ms) {
+        freshness.age_seconds =
+            (unsigned long)((current_tick_ms - last_reading_tick_ms) / 1000ULL);
+    }
+
+    return freshness;
+}

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -14,7 +14,7 @@
  * @req SWR-GUI-001  @req SWR-GUI-002  @req SWR-GUI-003  @req SWR-GUI-004
  * @req SWR-SEC-001  @req SWR-SEC-002  @req SWR-SEC-003
  * @req SWR-GUI-007  @req SWR-GUI-008  @req SWR-GUI-009  @req SWR-GUI-010
- * @req SWR-VIT-008  @req SWR-NEW-001
+ * @req SWR-GUI-014  @req SWR-VIT-008  @req SWR-NEW-001
  */
 #ifdef _MSC_VER
 #  define _CRT_SECURE_NO_WARNINGS
@@ -37,6 +37,7 @@
 #include "gui_users.h"
 #include "hw_vitals.h"
 #include "app_config.h"
+#include "dashboard_freshness.h"
 #include "localization.h"
 
 /* ===================================================================
@@ -206,7 +207,9 @@ typedef struct {
     int           has_patient;
     int           sim_paused;
     int           sim_enabled;  /**< 1=simulation mode, 0=device/HAL mode @req SWR-GUI-010 */
+    int           has_last_reading_tick;
     int           sim_msg_scroll_offset; /**< Offset for rolling message in simulation mode */
+    uint64_t      last_reading_tick_ms;
     AlarmLimits   alarm_limits; /**< Configurable per-parameter alarm limits @req SWR-ALM-001 */
 
     HFONT font_hdr;
@@ -240,6 +243,8 @@ static void apply_sim_mode(HWND dash);
 static void open_settings(HWND parent);
 static void open_pwddlg(HWND parent, const char *user, int admin_mode);
 static void open_adduser(HWND parent);
+static void clear_dashboard_freshness(void);
+static int accept_reading_and_stamp(const VitalSigns *reading);
 
 /* ===================================================================
  * GDI helpers
@@ -287,12 +292,74 @@ static void draw_pill(HDC hdc, int x, int y, int w, int h,
                  DT_SINGLELINE | DT_CENTER | DT_VCENTER);
 }
 
+static void clear_dashboard_freshness(void)
+{
+    g_app.last_reading_tick_ms = 0ULL;
+    g_app.has_last_reading_tick = 0;
+}
+
+static int accept_reading_and_stamp(const VitalSigns *reading)
+{
+    if (!patient_add_reading(&g_app.patient, reading)) {
+        return 0;
+    }
+
+    g_app.last_reading_tick_ms = (uint64_t)GetTickCount64();
+    g_app.has_last_reading_tick = 1;
+    return 1;
+}
+
+static DashboardFreshness current_dashboard_freshness(void)
+{
+    return dashboard_freshness_compute(g_app.sim_enabled,
+                                       g_app.sim_paused,
+                                       g_app.has_last_reading_tick,
+                                       (uint64_t)GetTickCount64(),
+                                       g_app.last_reading_tick_ms);
+}
+
+static int format_dashboard_freshness_text(char *buffer,
+                                           size_t buffer_size,
+                                           const DashboardFreshness *freshness)
+{
+    if (buffer == NULL || buffer_size == 0U || freshness == NULL) {
+        return 0;
+    }
+
+    switch (freshness->state) {
+    case DASHBOARD_FRESHNESS_DEVICE_MODE:
+        buffer[0] = '\0';
+        return 0;
+    case DASHBOARD_FRESHNESS_NO_READING:
+        snprintf(buffer, buffer_size, "%s",
+                 localization_get_string(STR_LAST_UPDATE_WAITING));
+        return 1;
+    case DASHBOARD_FRESHNESS_LIVE_AGE:
+        snprintf(buffer, buffer_size,
+                 localization_get_string(STR_LAST_UPDATE_AGE_SECONDS),
+                 freshness->age_seconds);
+        return 1;
+    case DASHBOARD_FRESHNESS_PAUSED_AGE:
+        snprintf(buffer, buffer_size,
+                 localization_get_string(STR_LAST_UPDATE_PAUSED_AGE_SECONDS),
+                 freshness->age_seconds);
+        return 1;
+    }
+
+    buffer[0] = '\0';
+    return 0;
+}
+
 /* ===================================================================
  * Painted zones — header
  * =================================================================== */
 static void paint_header(HDC hdc, int cw)
 {
-    char buf[128];
+    char freshness_buf[160];
+    char user_buf[128];
+    DashboardFreshness freshness = current_dashboard_freshness();
+    int has_freshness = format_dashboard_freshness_text(
+        freshness_buf, sizeof(freshness_buf), &freshness);
     fill_rect(hdc, 0, 0, cw, HDR_H, CLR_NAVY);
 
     /* Medical cross (white GDI rects) */
@@ -301,16 +368,25 @@ static void paint_header(HDC hdc, int cw)
 
     /* App title */
     draw_text_ex(hdc, "  " APP_TITLE,
-                 38, 0, cw - 480, HDR_H,
+                 38, has_freshness ? 4 : 0, cw - 480, has_freshness ? 24 : HDR_H,
                  g_app.font_hdr, CLR_WHITE,
-                 DT_SINGLELINE | DT_VCENTER | DT_LEFT);
+                 has_freshness
+                    ? (DT_SINGLELINE | DT_LEFT | DT_TOP)
+                    : (DT_SINGLELINE | DT_VCENTER | DT_LEFT));
+
+    if (has_freshness) {
+        draw_text_ex(hdc, freshness_buf,
+                     38, 30, cw - 480, 16,
+                     g_app.font_tile_lbl, RGB(191, 219, 254),
+                     DT_SINGLELINE | DT_LEFT | DT_END_ELLIPSIS);
+    }
 
     /* Info block — placed left of the header buttons (rightmost ~280px reserved for buttons) */
     if (g_app.logged_user[0]) {
         COLORREF badge_bg = (g_app.logged_role == ROLE_ADMIN) ? CLR_GOLD : CLR_TEAL;
         const char *badge_txt = (g_app.logged_role == ROLE_ADMIN) ? "ADMIN" : "CLINICAL";
-        snprintf(buf, sizeof(buf), "  %s", g_app.logged_user);
-        draw_text_ex(hdc, buf,
+        snprintf(user_buf, sizeof(user_buf), "  %s", g_app.logged_user);
+        draw_text_ex(hdc, user_buf,
                      cw - 560, 0, 160, HDR_H,
                      g_app.font_ui, RGB(186, 230, 253),
                      DT_SINGLELINE | DT_VCENTER | DT_LEFT);
@@ -805,6 +881,7 @@ static int do_admit(HWND w)
     }
     patient_init(&g_app.patient,id,name,age,wt,ht);
     g_app.has_patient=1;
+    clear_dashboard_freshness();
     update_dashboard(w); return 1;
 }
 static void do_add_reading(HWND w)
@@ -817,7 +894,7 @@ static void do_add_reading(HWND w)
     if (!parse_flt_field(w,IDC_VIT_TEMP,"Temperature",  &v.temperature))    return;
     if (!parse_int_field(w,IDC_VIT_SPO2,"SpO2",         &v.spo2))           return;
     if (!parse_int_field(w,IDC_VIT_RR,  "Resp Rate",    &v.respiration_rate)) return;
-    if (!patient_add_reading(&g_app.patient,&v)) {
+    if (!accept_reading_and_stamp(&v)) {
         MessageBoxA(w,"Reading buffer full (10 readings). Clear session to continue.",
                     APP_TITLE,MB_OK|MB_ICONWARNING); return;
     }
@@ -827,6 +904,7 @@ static void do_clear(HWND w)
 {
     ZeroMemory(&g_app.patient,sizeof(g_app.patient));
     g_app.has_patient=0;
+    clear_dashboard_freshness();
     set_txt(w,IDC_PAT_ID,    "1001"); set_txt(w,IDC_PAT_NAME,"Sarah Johnson");
     set_txt(w,IDC_PAT_AGE,   "52");   set_txt(w,IDC_PAT_WEIGHT,"72.5");
     set_txt(w,IDC_PAT_HEIGHT,"1.66"); set_txt(w,IDC_VIT_HR,"78");
@@ -850,7 +928,11 @@ static void do_scenario(HWND w, int s)
         set_txt(w,IDC_PAT_HEIGHT,"1.80"); rd=bra; n=2;
     }
     if (!do_admit(w)) return;
-    for (i=0;i<n;++i) patient_add_reading(&g_app.patient,&rd[i]);
+    for (i=0;i<n;++i) {
+        if (!accept_reading_and_stamp(&rd[i])) {
+            break;
+        }
+    }
     update_dashboard(w);
 }
 
@@ -1619,6 +1701,7 @@ static void apply_sim_mode(HWND dash)
         if (!g_app.has_patient) {
             patient_init(&g_app.patient, 2001, "James Mitchell", 45, 78.0f, 1.75f);
             g_app.has_patient = 1;
+            clear_dashboard_freshness();
             set_txt(dash,IDC_PAT_ID,"2001"); set_txt(dash,IDC_PAT_NAME,"James Mitchell");
             set_txt(dash,IDC_PAT_AGE,"45");  set_txt(dash,IDC_PAT_WEIGHT,"78.0");
             set_txt(dash,IDC_PAT_HEIGHT,"1.75");
@@ -1626,13 +1709,14 @@ static void apply_sim_mode(HWND dash)
         g_app.sim_paused = 0;
         SetWindowTextA(GetDlgItem(dash, IDC_BTN_PAUSE), localization_get_string(STR_PAUSE_SIM));
         hw_get_next_reading(&sv);
-        patient_add_reading(&g_app.patient, &sv);
+        accept_reading_and_stamp(&sv);
         SetTimer(dash, TIMER_SIM, 2000, NULL);
     } else {
         KillTimer(dash, TIMER_SIM);
         g_app.sim_paused = 0;
         ZeroMemory(&g_app.patient, sizeof(g_app.patient));
         g_app.has_patient = 0;
+        clear_dashboard_freshness();
     }
     update_dashboard(dash);
 }
@@ -1740,6 +1824,7 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
         alarm_limits_load(&g_app.alarm_limits);       /* restore alarm limits @req SWR-ALM-001 */
         hw_init();
         g_app.sim_paused = 0;
+        clear_dashboard_freshness();
 
         /* Pause Sim and demo buttons only visible when simulation is active */
         ShowWindow(GetDlgItem(w, IDC_BTN_PAUSE), g_app.sim_enabled ? SW_SHOW : SW_HIDE);
@@ -1753,7 +1838,7 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             set_txt(w,IDC_PAT_AGE,"45");  set_txt(w,IDC_PAT_WEIGHT,"78.0");
             set_txt(w,IDC_PAT_HEIGHT,"1.75");
             hw_get_next_reading(&first_v);
-            patient_add_reading(&g_app.patient, &first_v);
+            accept_reading_and_stamp(&first_v);
             SetTimer(w, TIMER_SIM, 2000, NULL);
         }
         reposition_dash_controls(w, WIN_CW);   /* initial layout */
@@ -1781,22 +1866,30 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
     }
 
     case WM_TIMER:
-        if (wp == TIMER_SIM && g_app.sim_enabled && !g_app.sim_paused) {
-            VitalSigns v;
-            if (g_app.has_patient && patient_is_full(&g_app.patient)) {
-                int previous_reading_count = g_app.patient.reading_count;
-                patient_init(&g_app.patient,
-                             g_app.patient.info.id, g_app.patient.info.name,
-                             g_app.patient.info.age, g_app.patient.info.weight_kg,
-                             g_app.patient.info.height_m);
-                patient_note_session_reset(&g_app.patient, previous_reading_count);
+        if (wp == TIMER_SIM && g_app.sim_enabled) {
+            if (g_app.sim_paused) {
+                InvalidateRect(w, NULL, FALSE);
+                return 0;
             }
-            hw_get_next_reading(&v);
-            patient_add_reading(&g_app.patient, &v);
-            g_app.has_patient = 1;
-            /* Advance rolling message in simulation mode */
-            g_app.sim_msg_scroll_offset = (g_app.sim_msg_scroll_offset + 3) % 800;
-            update_dashboard(w);
+
+            {
+                VitalSigns v;
+                if (g_app.has_patient && patient_is_full(&g_app.patient)) {
+                    int previous_reading_count = g_app.patient.reading_count;
+                    patient_init(&g_app.patient,
+                                 g_app.patient.info.id, g_app.patient.info.name,
+                                 g_app.patient.info.age, g_app.patient.info.weight_kg,
+                                 g_app.patient.info.height_m);
+                    patient_note_session_reset(&g_app.patient, previous_reading_count);
+                    clear_dashboard_freshness();
+                }
+                hw_get_next_reading(&v);
+                accept_reading_and_stamp(&v);
+                g_app.has_patient = 1;
+                /* Advance rolling message in simulation mode */
+                g_app.sim_msg_scroll_offset = (g_app.sim_msg_scroll_offset + 3) % 800;
+                update_dashboard(w);
+            }
         }
         return 0;
 
@@ -1844,6 +1937,7 @@ static LRESULT CALLBACK dash_proc(HWND w, UINT msg, WPARAM wp, LPARAM lp)
             ZeroMemory(&g_app.patient, sizeof(g_app.patient));
             g_app.has_patient    = 0;
             g_app.sim_paused     = 0;
+            clear_dashboard_freshness();
             g_app.logged_user[0] = '\0';
             g_app.logged_username[0] = '\0';
             g_app.hwnd_login = CreateWindowExA(

--- a/src/localization.c
+++ b/src/localization.c
@@ -82,6 +82,9 @@ static const char* g_strings_english[STR_COUNT] = {
     "Remove User",                  /* STR_REMOVE_USER */
     "Role",                         /* STR_ROLE */
     "Admin",                        /* STR_ADMIN */
+    "Last update: awaiting first reading",               /* STR_LAST_UPDATE_WAITING */
+    "Last update: %lu s ago",                            /* STR_LAST_UPDATE_AGE_SECONDS */
+    "Feed paused - last update: %lu s ago",              /* STR_LAST_UPDATE_PAUSED_AGE_SECONDS */
     "Clinical",                     /* STR_CLINICAL */
 
     "ALL NORMAL — Patient stable [ SIMULATION MODE ]",  /* STR_STATUS_NORMAL */
@@ -155,6 +158,9 @@ static const char* g_strings_spanish[STR_COUNT] = {
     "Eliminar Usuario",
     "Rol",
     "Administrador",
+    "Ultima actualizacion: esperando la primera lectura",
+    "Ultima actualizacion: hace %lu s",
+    "Flujo en pausa - ultima actualizacion: hace %lu s",
     "Clínico",
 
     "TODO NORMAL — Paciente estable [ MODO SIMULACIÓN ]",
@@ -228,6 +234,9 @@ static const char* g_strings_french[STR_COUNT] = {
     "Supprimer un Utilisateur",
     "Rôle",
     "Administrateur",
+    "Derniere mise a jour : premiere lecture en attente",
+    "Derniere mise a jour : il y a %lu s",
+    "Flux en pause - derniere mise a jour : il y a %lu s",
     "Clinique",
 
     "TOUT NORMAL — Patient stable [ MODE SIMULATION ]",
@@ -301,6 +310,9 @@ static const char* g_strings_german[STR_COUNT] = {
     "Benutzer Entfernen",
     "Rolle",
     "Administrator",
+    "Letzte Aktualisierung: erste Messung ausstehend",
+    "Letzte Aktualisierung: vor %lu s",
+    "Zufuhr pausiert - letzte Aktualisierung: vor %lu s",
     "Klinisch",
 
     "ALLES NORMAL — Patient stabil [ SIMULATIONSMODUS ]",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(test_unit
     unit/test_hal.cpp
     unit/test_config.cpp
     unit/test_localization.cpp
+    unit/test_dashboard_freshness.cpp
     unit/test_news2.cpp
     unit/test_alarm_limits.cpp
     unit/test_trend.cpp

--- a/tests/unit/test_dashboard_freshness.cpp
+++ b/tests/unit/test_dashboard_freshness.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file test_dashboard_freshness.cpp
+ * @brief Unit tests for dashboard freshness-state calculation.
+ *
+ * @req SWR-GUI-014
+ */
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "dashboard_freshness.h"
+}
+
+TEST(DashboardFreshness, REQ_GUI_014_DeviceModeSuppressesCue)
+{
+    DashboardFreshness freshness =
+        dashboard_freshness_compute(0, 0, 1, 7000ULL, 1000ULL);
+
+    EXPECT_EQ(DASHBOARD_FRESHNESS_DEVICE_MODE, freshness.state);
+    EXPECT_EQ(0UL, freshness.age_seconds);
+}
+
+TEST(DashboardFreshness, REQ_GUI_014_NoReadingReturnsWaitingState)
+{
+    DashboardFreshness freshness =
+        dashboard_freshness_compute(1, 0, 0, 7000ULL, 0ULL);
+
+    EXPECT_EQ(DASHBOARD_FRESHNESS_NO_READING, freshness.state);
+    EXPECT_EQ(0UL, freshness.age_seconds);
+}
+
+TEST(DashboardFreshness, REQ_GUI_014_LiveAgeUsesWholeSecondsSinceAcceptance)
+{
+    DashboardFreshness freshness =
+        dashboard_freshness_compute(1, 0, 1, 9876ULL, 4321ULL);
+
+    EXPECT_EQ(DASHBOARD_FRESHNESS_LIVE_AGE, freshness.state);
+    EXPECT_EQ(5UL, freshness.age_seconds);
+}
+
+TEST(DashboardFreshness, REQ_GUI_014_PausedAgeReusesSameTickBasis)
+{
+    DashboardFreshness freshness =
+        dashboard_freshness_compute(1, 1, 1, 12500ULL, 2000ULL);
+
+    EXPECT_EQ(DASHBOARD_FRESHNESS_PAUSED_AGE, freshness.state);
+    EXPECT_EQ(10UL, freshness.age_seconds);
+}
+
+TEST(DashboardFreshness, REQ_GUI_014_TickRegressionClampsAgeToZero)
+{
+    DashboardFreshness freshness =
+        dashboard_freshness_compute(1, 0, 1, 1500ULL, 3000ULL);
+
+    EXPECT_EQ(DASHBOARD_FRESHNESS_LIVE_AGE, freshness.state);
+    EXPECT_EQ(0UL, freshness.age_seconds);
+}


### PR DESCRIPTION
## Summary
- add a presentation-only freshness helper that computes device/no-reading/live/paused header states from monotonic ticks
- stamp accepted readings in the dashboard flow and keep paused sessions repainting so the age cue continues to advance without new data
- add localized header strings, SWR/RTM updates, and a focused unit test suite for the freshness model

## Validation
- `cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DBUILD_TESTS=ON -Wno-dev`
- `cmake --build build --target test_unit test_integration`
- `ctest --test-dir build --output-on-failure`

Closes #72